### PR TITLE
Fix links to color definition spec

### DIFF
--- a/source/versions/ufo3/fontinfo.html
+++ b/source/versions/ufo3/fontinfo.html
@@ -1472,7 +1472,7 @@
 		<tr>
 			<td>color</td>
 			<td>string</td>
-			<td>The color that should be applied to the guideline. The format follows the <a href="#color">color definition</a> standard. This attribute is optional.</td>
+			<td>The color that should be applied to the guideline. The format follows the <a href="conventions.html#color">color definition</a> standard. This attribute is optional.</td>
 			<td>no color</td>
 		</tr>
 		<tr>

--- a/source/versions/ufo3/glif.html
+++ b/source/versions/ufo3/glif.html
@@ -227,7 +227,7 @@
 		<tr>
 			<td>color</td>
 			<td>string</td>
-			<td>The color that should be applied to the image. The format follows the <a href="#color">color definition</a> standard. This attribute is optional.</td>
+			<td>The color that should be applied to the image. The format follows the <a href="conventions.html#color">color definition</a> standard. This attribute is optional.</td>
 			<td>no color</td>
 		</tr>
 	</table>
@@ -301,7 +301,7 @@
 		<tr>
 			<td>color</td>
 			<td>string</td>
-			<td>The color that should be applied to the guideline. The format follows the <a href="#color">color definition</a> standard. This attribute is optional.</td>
+			<td>The color that should be applied to the guideline. The format follows the <a href="conventions.html#color">color definition</a> standard. This attribute is optional.</td>
 			<td>no color</td>
 		</tr>
 		<tr>
@@ -355,7 +355,7 @@
 		<tr>
 			<td>color</td>
 			<td>string</td>
-			<td>The color that should be applied to the anchor. The format follows the <a href="#color">color definition</a> standard. This attribute is optional.</td>
+			<td>The color that should be applied to the anchor. The format follows the <a href="conventions.html#color">color definition</a> standard. This attribute is optional.</td>
 			<td>no color</td>
 		</tr>
 		<tr>
@@ -631,7 +631,7 @@
 
 	<h5>public.markColor</h5>
 	<p>
-		This key is used for representing the "mark" color seen in various font editors. The value for the key must be a string following the <a href="#color">color definition</a> standard. This data is optional.
+		This key is used for representing the "mark" color seen in various font editors. The value for the key must be a string following the <a href="conventions.html#color">color definition</a> standard. This data is optional.
 	</p>
 
 	<!-- Example -->


### PR DESCRIPTION
Changes the links which reference a color spec to point to the `conventions.html` document which has the appropriate section.

Fixes #10
