### PR TITLE
Add space above h2 and h3 elements

### DIFF
--- a/source/media/styles.css
+++ b/source/media/styles.css
@@ -52,7 +52,7 @@ h2 {
 	margin-right: 0px;
 	margin-left: 0px;
 	margin-bottom: 10px;
-	margin-top: 10px;
+	margin-top: 50px;
 	padding: 5px 10px 5px 10px;
 	font-size: 15px;
 	font-weight: bold;
@@ -63,7 +63,7 @@ h2 {
 h3 {
 	padding: 0px;
 	margin-bottom: 10px;
-	margin-top: 15px;
+	margin-top: 50px;
 	padding: 5px 10px 5px 10px;
 	border: 1px #cc0000 solid;
 	font-size: 11px;


### PR DESCRIPTION
This is certainly a cosmetic change, but one that helps me read the spec. Currently it's difficult to see `h3` headlines, especially after sections that end in a table.

This change simply updates both the `h2` and `h3` elements to have 50 pixels of margin above, rather than 10 and 15, respectively.

![screen shot 2014-12-03 at 1 15 50 pm](https://cloud.githubusercontent.com/assets/46891/5289027/480b39f0-7aef-11e4-8593-32f54a9761c0.png)
