### PR TITLE
Update kerning.plist.md

### DIFF
--- a/versions/ufo3/kerning.plist.md
+++ b/versions/ufo3/kerning.plist.md
@@ -446,7 +446,7 @@ def test():
 ```
 
   [XML Property List]: conventions.html#propertylist
-  [groups.plist specification]: groups.html
+  [groups.plist specification]: groups.plist
   [exception]: #kerning-pair-exceptions
   [exception-conflict-resolution]: #exception-conflict-resolution
-  [group's name]: groups.html
+  [group's name]: groups.plist


### PR DESCRIPTION
.html is not used anymore

its either nothing or the extension of the file itself, in this case use groups.plist in the url
