### PR TITLE
Add documentation for public.postscript.hints

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -3,33 +3,22 @@ layout: default
 title: Glyph Interchange Format
 ---
 
-| **File Format** | XML |
-
-The Glyph Interchange Format (GLIF) is a simple and clear XML representation of a single glyph. GLIF files typically have a *.glif* extension.
+The Glyph Interchange Format (GLIF) is a simple and clear XML representation of
+a single glyph. GLIF files typically have a *.glif* extension.
 
 The GLIF data follows this structure:
 
+{: .filediagram} - glyph - advance - unicode - note - image - guideline - anchor
+- outline - contour - point - component - lib
 
-{: .filediagram}
-- glyph
-- advance
-- unicode
-- note
-- image
-- guideline
-- anchor
-- outline
-  - contour
-    - point
-  - component
-- lib
+Specification
+-------------
 
-## Specification
+In all elements, where an attribute has a defined default value the attribute is
+optional unless otherwise stated. If the attribute is not defined, the value for
+the attribute is implicitly the default value.
 
-In all elements, where an attribute has a defined default value the attribute is optional unless otherwise stated. If the attribute is not defined, the value for the attribute is implicitly the default value.
-
-{: #glyph }
-### glyph: The top level element.
+{: \#glyph } \#\#\# glyph: The top level element.
 
 #### Attributes
 
@@ -38,23 +27,28 @@ In all elements, where an attribute has a defined default value the attribute is
 | name           | The name of the glyph. This must be at least one character long. Different font specifications, such as OpenType, often have their own glyph name restrictions. Authoring tools should not make assumptions about the validity of a glyph's name for a particular font specification. |
 | format         | The format version. 2 for this version.                                                                                                                                                                                                                                               |
 
-The `name` attribute has limited uses in this version. The *contents.plist* file maps glyph names to file names, and one of the reasons to do this is to avoid having to parse all files just to get at a list of available glyph names. When reading GLIF files, the `name` attribute should be ignored, since manual editing may have caused a mismatch with the glyph name as stored in *contents.plist*, as well as with the file name, which is an algorithmic transformation of the glyph name. This attribute may become more useful in future versions of GLIF.
+The `name` attribute has limited uses in this version. The *contents.plist* file
+maps glyph names to file names, and one of the reasons to do this is to avoid
+having to parse all files just to get at a list of available glyph names. When
+reading GLIF files, the `name` attribute should be ignored, since manual editing
+may have caused a mismatch with the glyph name as stored in *contents.plist*, as
+well as with the file name, which is an algorithmic transformation of the glyph
+name. This attribute may become more useful in future versions of GLIF.
 
 #### Child Elements
 
-| element name | description                    |
-|--------------|--------------------------------|
-| [advance]    | May occur at most once.        |
-| [unicode]    | May occur any number of times. |
-| [note]       | May occur at most once.        |
-| [image]      | May occur at most once.        |
-| [guideline]  | May occur any number of times. |
-| [anchor]     | May occur any number of times. |
-| [outline]    | May occur at most once.        |
-| [lib]        | May occur at most once.        |
+| element name            | description                    |
+|-------------------------|--------------------------------|
+| [advance](#advance)     | May occur at most once.        |
+| [unicode](#unicode)     | May occur any number of times. |
+| [note](#note)           | May occur at most once.        |
+| [image](#image)         | May occur at most once.        |
+| [guideline](#guideline) | May occur any number of times. |
+| [anchor](#anchor)       | May occur any number of times. |
+| [outline](#outline)     | May occur at most once.        |
+| [lib](#lib)             | May occur at most once.        |
 
-{: #advance }
-### advance: Horizontal and vertical metrics.
+{: \#advance } \#\#\# advance: Horizontal and vertical metrics.
 
 #### Attributes
 
@@ -67,12 +61,11 @@ The `name` attribute has limited uses in this version. The *contents.plist* file
 
 #### Example
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <advance width="400" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{: #unicode }
-### unicode: Unicode code point.
+{: \#unicode } \#\#\# unicode: Unicode code point.
 
 #### Attributes
 
@@ -82,35 +75,41 @@ The `name` attribute has limited uses in this version. The *contents.plist* file
 
 #### This element has no child elements.
 
-The first occurrence of this element defines the primary Unicode value for this glyph.
+The first occurrence of this element defines the primary Unicode value for this
+glyph.
 
 #### Example
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <unicode hex="0041" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{: #image }
-### image: An image reference.
+{: \#image } \#\#\# image: An image reference.
 
-This optional element represents an image element in a glyph. It may occur at most once. The image should always be considered to be *behind* the outline element.
+This optional element represents an image element in a glyph. It may occur at
+most once. The image should always be considered to be *behind* the outline
+element.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                    | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------|
-| fileName       | string           | The image file name, including any file extension, not an absolute or relative path in the file system.                        | None          |
-| xScale         | integer or float | See below.                                                                                                                     | 1             |
-| xyScale        | integer or float | See below.                                                                                                                     | 0             |
-| yxScale        | integer or float | See below.                                                                                                                     | 0             |
-| yScale         | integer or float | See below.                                                                                                                     | 1             |
-| xOffset        | integer or float | See below.                                                                                                                     | 0             |
-| yOffset        | integer or float | See below.                                                                                                                     | 0             |
-| color          | string           | The color that should be applied to the image. The format follows the [color definition] standard. This attribute is optional. | no color      |
+| attribute name | data type        | description                                                                                                                                             | default value |
+|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| fileName       | string           | The image file name, including any file extension, not an absolute or relative path in the file system.                                                 | None          |
+| xScale         | integer or float | See below.                                                                                                                                              | 1             |
+| xyScale        | integer or float | See below.                                                                                                                                              | 0             |
+| yxScale        | integer or float | See below.                                                                                                                                              | 0             |
+| yScale         | integer or float | See below.                                                                                                                                              | 1             |
+| xOffset        | integer or float | See below.                                                                                                                                              | 0             |
+| yOffset        | integer or float | See below.                                                                                                                                              | 0             |
+| color          | string           | The color that should be applied to the image. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional. | no color      |
 
-`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that order form an Affine transformation matrix, to be used to transform the image. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
+`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that
+order form an Affine transformation matrix, to be used to transform the image.
+The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
 
-One image width unit equals one horizontal font unit and one image height unit equals one vertical font unit **before** `xScale, xyScale, yxScale, yScale, xOffset, yOffset` are applied.
+One image width unit equals one horizontal font unit and one image height unit
+equals one vertical font unit **before** `xScale, xyScale, yxScale, yScale,
+xOffset, yOffset` are applied.
 
 #### This element has no child elements.
 
@@ -120,142 +119,155 @@ All images must be in Portable Network Graphics (PNG) format.
 
 #### Coloring Images
 
-There are two places that the color for an image can be defined: the color attribute of the image element and the `color` defined in [layerinfo.plist]. The color defined in the image element's color attribute always takes precedence. If that is not defined and the `color` is defined for the layer, the layer's `color` should be used. If both of these are undefined, the image's colors, without modification, should be used unless an authoring tool has a default color for images. If a color is to be applied, the authoring tool should convert the image to grayscale and then apply the color. This modified version of the image must not be saved into the images directory.
+There are two places that the color for an image can be defined: the color
+attribute of the image element and the `color` defined in
+[layerinfo.plist](glyphs.html#layerinfo). The color defined in the image
+element's color attribute always takes precedence. If that is not defined and
+the `color` is defined for the layer, the layer's `color` should be used. If
+both of these are undefined, the image's colors, without modification, should be
+used unless an authoring tool has a default color for images. If a color is to
+be applied, the authoring tool should convert the image to grayscale and then
+apply the color. This modified version of the image must not be saved into the
+images directory.
 
 #### Example
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <image fileName="Sketch 1.png" xOffset="100" yOffset="200"
     xScale=".75" yScale=".75" color="1,0,0,.5" />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-```
-
-{: #guideline }
-### guideline: A reference guideline.
+{: \#guideline } \#\#\# guideline: A reference guideline.
 
 This element may occur any number of times.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate. Optional if `y` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None          |
-| y              | integer or float | The 'y' coordinate. Optional if `x` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None          |
-| angle          | integer or float | The angle of the guideline. This must be an angle between 0 and 360 degrees in a clockwise direction from the horizontal. If `x` or `y` are not specified, `angle` must not be specified. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | None          |
-| name           | string           | An arbitrary name for the guideline. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no name       |
-| color          | string           | The color that should be applied to the guideline. The format follows the [color definition] standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | no color      |
-| identifier     | string           | Unique identifier for the guideline. This attribute is not required and should only be added to guidelines as needed. However, once an identifier has been assigned to a guideline it must not be unnecessarily removed or changed. Identifiers may be changed in incoming guidelines during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than guidelines) in the glyph that the guideline belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate. Optional if `y` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | None          |
+| y              | integer or float | The 'y' coordinate. Optional if `x` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | None          |
+| angle          | integer or float | The angle of the guideline. This must be an angle between 0 and 360 degrees in a clockwise direction from the horizontal. If `x` or `y` are not specified, `angle` must not be specified. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | None          |
+| name           | string           | An arbitrary name for the guideline. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | no name       |
+| color          | string           | The color that should be applied to the guideline. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | no color      |
+| identifier     | string           | Unique identifier for the guideline. This attribute is not required and should only be added to guidelines as needed. However, once an identifier has been assigned to a guideline it must not be unnecessarily removed or changed. Identifiers may be changed in incoming guidelines during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than guidelines) in the glyph that the guideline belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
 
-The guideline extends along `angle` to infinity in both directions out of the point defined by `x` and `y`. If `y` and `angle` are omitted, the element represents a vertical guideline. If `x` and `angle` are omitted, the element represents a horizontal guideline.
+The guideline extends along `angle` to infinity in both directions out of the
+point defined by `x` and `y`. If `y` and `angle` are omitted, the element
+represents a vertical guideline. If `x` and `angle` are omitted, the element
+represents a horizontal guideline.
 
 #### This element has no child elements.
 
-{: #anchor }
-### anchor: A reference position.
+{: \#anchor } \#\#\# anchor: A reference position.
 
 This element may occur any number of times.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | default value |
-|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | None          |
-| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | None          |
-| name           | string           | An arbitrary name for the anchor. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | no name       |
-| color          | string           | The color that should be applied to the anchor. The format follows the [color definition] standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no color      |
-| identifier     | string           | Unique identifier for the anchor. This attribute is not required and should only be added to anchors as needed. However, once an identifier has been assigned to an anchor it must not be unnecessarily removed or changed. Identifiers may be changed in incoming anchors during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than anchors) in the glyph that the anchor belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | default value |
+|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | None          |
+| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | None          |
+| name           | string           | An arbitrary name for the anchor. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no name       |
+| color          | string           | The color that should be applied to the anchor. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | no color      |
+| identifier     | string           | Unique identifier for the anchor. This attribute is not required and should only be added to anchors as needed. However, once an identifier has been assigned to an anchor it must not be unnecessarily removed or changed. Identifiers may be changed in incoming anchors during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than anchors) in the glyph that the anchor belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
 
 #### This element has no child elements.
 
 #### Converting implied anchors in GLIF 1 to GLIF 2 anchor elements
 
-In GLIF 1 there was no official anchor element. Anchors were unofficially but widely supported through the use of a contour containing only one "move" point. For example:
+In GLIF 1 there was no official anchor element. Anchors were unofficially but
+widely supported through the use of a contour containing only one "move" point.
+For example:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <contour>
   <point x="250" y="650" type="move" name="top"/>
 </contour>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-```
+Authoring tools may convert instances of contours like this to anchor elements
+when converting GLIF 1 to GLIF 2. The required `x` and `y` and optional `name`
+attributes directly map to the same attributes of the anchor element.
 
-Authoring tools may convert instances of contours like this to anchor elements when converting GLIF 1 to GLIF 2. The required `x` and `y` and optional `name` attributes directly map to the same attributes of the anchor element.
-
-{: #outline }
-### outline: Outline description.
+{: \#outline } \#\#\# outline: Outline description.
 
 #### This element has no attributes.
 
 #### Child Elements
 
-| element name | description                    |
-|--------------|--------------------------------|
-| [component]  | May occur any number of times. |
-| [contour]    | May occur any number of times. |
+| element name            | description                    |
+|-------------------------|--------------------------------|
+| [component](#component) | May occur any number of times. |
+| [contour](#contour)     | May occur any number of times. |
 
-{: #component }
-### component: Insert another glyph as part of the outline.
+{: \#component } \#\#\# component: Insert another glyph as part of the outline.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| base           | string           | Name of the base glyph                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | None          |
-| xScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1             |
-| xyScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
-| yxScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
-| yScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1             |
-| xOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
-| yOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
-| identifier     | string           | Unique identifier for the component. This attribute is not required and should only be added to components as needed. However, once an identifier has been assigned to a component it must not be unnecessarily removed or changed. Identifiers may be changed in incoming components during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than components) in the glyph that the component belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| base           | string           | Name of the base glyph                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | None          |
+| xScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1             |
+| xyScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
+| yxScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
+| yScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1             |
+| xOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
+| yOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
+| identifier     | string           | Unique identifier for the component. This attribute is not required and should only be added to components as needed. However, once an identifier has been assigned to a component it must not be unnecessarily removed or changed. Identifiers may be changed in incoming components during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than components) in the glyph that the component belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
 
-`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that order form an Affine transformation matrix, to be used to transform the base glyph. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
+`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that
+order form an Affine transformation matrix, to be used to transform the base
+glyph. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
 
-The base glyph referenced by a component may contain components. The base glyph must not create a circular reference to the glyph that contains the component. Components must only reference glyphs within the same layer that the component belongs to.
+The base glyph referenced by a component may contain components. The base glyph
+must not create a circular reference to the glyph that contains the component.
+Components must only reference glyphs within the same layer that the component
+belongs to.
 
 #### This element has no child elements.
 
 #### Example
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <component base="A" xOffset="100" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{: #contour }
-### contour: Contour description.
+{: \#contour } \#\#\# contour: Contour description.
 
 #### Attributes
 
-| attribute name | data type | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
-|----------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| identifier     | string    | Unique identifier for the component. This attribute is not required and should only be added to contours as needed. However, once an identifier has been assigned to a contour it must not be unnecessarily removed or changed. Identifiers may be changed in incoming contours during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than contours) in the glyph that the contour belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
+| attribute name | data type | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | default value |
+|----------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| identifier     | string    | Unique identifier for the component. This attribute is not required and should only be added to contours as needed. However, once an identifier has been assigned to a contour it must not be unnecessarily removed or changed. Identifiers may be changed in incoming contours during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than contours) in the glyph that the contour belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
 
 #### Child Elements
 
-| element name | description                    |
-|--------------|--------------------------------|
-| [point]      | May occur any number of times. |
+| element name    | description                    |
+|-----------------|--------------------------------|
+| [point](#point) | May occur any number of times. |
 
-There is no requirement that a contour contain an on-curve point. If a contour contains only off-curve points the contour must be treated as a quadratic curve.
+There is no requirement that a contour contain an on-curve point. If a contour
+contains only off-curve points the contour must be treated as a quadratic curve.
 
-{: #point }
-### point: An attributed coordinate pair.
+{: \#point } \#\#\# point: An attributed coordinate pair.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | None          |
-| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | None          |
-| type           | string           | The point and/or segment type. The options are detailed below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | offcurve      |
-| smooth         | string           | This attribute must only be given when `type` indicates the point is on-curve. When set to `yes`, it signifies that a smooth curvature should be maintained at this point, either as a `curve point` or a `tangent point` in Fontographer terms. This attribute may be set for all point types except `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | no            |
-| name           | string           | Arbitrary name or label for this point. The name does not have to be unique within a contour, nor within an outline.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | no name       |
-| identifier     | string           | Unique identifier for the point. This attribute is not required and should only be added to points as needed. However, once an identifier has been assigned to a point it must not be unnecessarily removed or changed. Identifiers may be changed in incoming points during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than poinys) in the glyph that the point belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | None          |
+| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | None          |
+| type           | string           | The point and/or segment type. The options are detailed below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | offcurve      |
+| smooth         | string           | This attribute must only be given when `type` indicates the point is on-curve. When set to `yes`, it signifies that a smooth curvature should be maintained at this point, either as a `curve point` or a `tangent point` in Fontographer terms. This attribute may be set for all point types except `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | no            |
+| name           | string           | Arbitrary name or label for this point. The name does not have to be unique within a contour, nor within an outline.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | no name       |
+| identifier     | string           | Unique identifier for the point. This attribute is not required and should only be added to points as needed. However, once an identifier has been assigned to a point it must not be unnecessarily removed or changed. Identifiers may be changed in incoming points during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than poinys) in the glyph that the point belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
 
 ##### Point Types
 
-|          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | move     | A point of this type must be the first in a `contour`. The reverse is not true: a `contour` does not necessarily start with a `move` point. When a `contour` **does** start with a `move` point, it signifies the beginning of an **open** contour. A **closed** contour does **not** start with a `move` and is defined as a cyclic list of points, with no predominant start point. There is always a *next point* and a *previous point*. For this purpose the list of points can be seen as endless in both directions. The actual list of points can be rotated arbitrarily (by removing the first N points and appending them at the end) while still describing the same outline. |
+|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | line     | Draw a straight line from the previous point to this point. The previous point must be a `move`, a `line`, a `curve` or a `qcurve`. It must not be an `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | offcurve | This point is part of a curve segment that goes up to the next point that is either a `curve` or a `qcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | curve    | Draw a cubic bezier curve from the last non-*offcurve* point to this point. The number of *offcurve* points can be zero, one or two. If the number of `offcurve` points is zero, a straight line is drawn. If it is one, a quadratic curve is drawn. If it is two, a regular cubic bezier is drawn.                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -267,96 +279,128 @@ There is no requirement that a contour contain an on-curve point. If a contour c
 
 move point:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <point x="433" y="371" type="move" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 line point:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <point x="433" y="371" type="line" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 offcurve point:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <point x="433" y="366" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 curve point:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <point x="441" y="363" type="curve" smooth="yes" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 qcurve point:
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <point x="441" y="363" type="qcurve" />
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{: #note }
-### note: Note about the glyph.
+{: \#note } \#\#\# note: Note about the glyph.
 
-This element is a place for the user to define arbitrary text about the glyph. There is no standardized structure for the note apart from that it being the content of the note element.
+This element is a place for the user to define arbitrary text about the glyph.
+There is no standardized structure for the note apart from that it being the
+content of the note element.
 
-{: #lib }
-### lib: Custom data storage.
+{: \#lib } \#\#\# lib: Custom data storage.
 
-This element is a place to store authoring tool specific, user specific or otherwise arbitrary data for the glyph. lib mus have one child element that is structure as a dictionary formatted as an [XML Property List]. This element may occur at most once. In order to prevent conflicts in the lib, keys in the top level should follow a [reverse domain naming scheme]. The pattern "public.\*", where \* represents an arbitrary string of one or more characters, is reserved for use in standardized lib keys. It is recommended that the data stored as a value be as shallow as possible.
+This element is a place to store authoring tool specific, user specific or
+otherwise arbitrary data for the glyph. lib mus have one child element that is
+structure as a dictionary formatted as an [XML Property
+List](conventions.html#propertylist). This element may occur at most once. In
+order to prevent conflicts in the lib, keys in the top level should follow a
+[reverse domain naming scheme](conventions.html#reversedomain). The pattern
+"public.\*", where \* represents an arbitrary string of one or more characters,
+is reserved for use in standardized lib keys. It is recommended that the data
+stored as a value be as shallow as possible.
 
-Data that is too complex or too large for lib can be stored in the [data directory].
+Data that is too complex or too large for lib can be stored in the [data
+directory](data.html).
 
 #### Common Key Registry
 
-The following is a registry of public lib keys that map to functionality that is often seen in font editing applications but is not suitable for storage elsewhere in this particular version of the UFO.
+The following is a registry of public lib keys that map to functionality that is
+often seen in font editing applications but is not suitable for storage
+elsewhere in this particular version of the UFO.
 
 ##### public.markColor
 
-This key is used for representing the "mark" color seen in various font editors. The value for the key must be a string following the [color definition] standard. This data is optional.
+This key is used for representing the "mark" color seen in various font editors.
+The value for the key must be a string following the [color
+definition](conventions.html#colors) standard. This data is optional.
 
 ##### public.verticalOrigin
 
-This key is used for representing the "vertical origin" 'y' coordinate used for vertical layout. The value for the key must be an integer or float. This data is optional. Authoring tools can use this data and the advance element's `height` attribute to create the VORG and vmtx tables.
+This key is used for representing the "vertical origin" 'y' coordinate used for
+vertical layout. The value for the key must be an integer or float. This data is
+optional. Authoring tools can use this data and the advance element's `height`
+attribute to create the VORG and vmtx tables.
 
 #### public.postscript.hints
 
-This key provides a dict defining a set of PostScript hints for a glyph. The key is optional. Note that the set of hints become invalid whenever the outline is edited so as to change point types or coordinates. Rather than requiring all editing apps to remove hints whenever the outline is changed, the hint dict "id" is provided so that a third party can see if the current outline differs from what was present when the hints were last derived. If the hash for the current outline differs from the hint dict "id" value, then the hints are invalid for the current outline, and should be discarded.
+This key provides a dict defining a set of PostScript hints for a glyph. The key
+is optional. Note that the set of hints become invalid whenever the outline is
+edited so as to change point types or coordinates. Rather than requiring all
+editing apps to remove hints whenever the outline is changed, the hint dict "id"
+is provided so that a third party can see if the current outline differs from
+what was present when the hints were last derived. If the hash for the current
+outline differs from the hint dict "id" value, then the hints are invalid for
+the current outline, and should be discarded.
 
 #### Hint Dict
 
-| key         | value type | description                                                                                                                                                                                                                                                  |
-|-------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| formatVersion    | string     | format version. Currently "1", the first public version.                                                                                                                                                               |
-| id          | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
-| hintSetList | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
-| flexList    | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
+| key           | value type | description                                                                                                                                                                                                                                                  |
+|---------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| formatVersion | string     | format version. Currently "1", the first public version.                                                                                                                                                                                                     |
+| id            | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
+| hintSetList   | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
+| flexList      | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
 
 #### Hint Set
 
 | key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 |----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| pointTag | string          | unique point name. Must match a point name attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| pointTag | string          | unique point name. Must match a point ‘name' attribute.                                                                                                                                                                                                                                                                                                                                                                                                      |
 | stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
 
-*Hint ID computation.* The glyph is flattened to a single set of contours, with
-all transformations. The contours are converted to a string by iterating through
-all the points. For each point in each contour, the GLIF point type is appended,
-then the x and y value are converted to decimal strings and appended; white
-space is omitted. Any contour with a length of less than 2 is skipped.
+*Hint ID computation.* The hash string is initialized with the width value as a
+decimal string, with the prefix w'. The glyph outline element is converted to a
+string by iterating through all the child elements.
 
-For each component, the hash function is applied to the component glyph, and the
-hash string for the component glyph is then appended to the hash string for the
-parent glyph.
+If the child is a contour element, it is converted to a string and added to the
+hash string by iterating through all the point elements. Any contour with a
+length of less than 2 is skipped. For each point, the point 'type' attribute, if
+present, is written; else a space is written. The x and y values are then
+written as decimal strings separated by a comma. The x and y values are rounded
+to a precision of no more than 3 decimal places.
+
+If the child is a component element, first the transform values are written, if
+any. These are written by writing 't' followed by the comma-separated decimal
+values of the transform attributes in the following order: ["xScale", "xyScale",
+"yxScale","yScale", "xOffset", "yOffset"]. The letter 'h' is then written,
+followed by the hash ID for the component glyph. The four scale values will be
+rounded to a precision of 8 decimal places, and the offset values will be
+rounded to a precision of at most 3 decimal places.
 
 Once the hash string is built, it is used as is for the Hint ID if it is less
 than 128 characters. Otherwise, a SHA 512 hash is computed, and this is used as
-the Hint ID for the hint dict.
-
+the Hint ID for the hint dict. The SHA 512 hash is written with lowercase
+hexidecimal digits.
 
 ### Example
 
-```xml
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="period" format="2">
   <advance width="268"/>
@@ -387,68 +431,32 @@ the Hint ID for the hint dict.
       <key>public.markColor</key>
       <string>1,0,0,0.5</string>
       <key>public.postscript.hints</key>
-    <dict>
-        <key>formatVersion<key><string>1</string>
-        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
-      <key>hintSetList</key>
-      <array>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0000</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0005</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 454 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0016</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-      </array>
-    </dict>
+      <dict>
+        <key>formatVersion</key><string>1</string>
+        <key>id</key><string>w268c237,88 237,152 193,187c134,187 74,187 30,150c30,88 30,23 74,-10c134,-10 193,-10 237,25</string>
+        <key>hintSetList</key>
+        <array>
+          <dict>
+            <key>pointTag</key>
+            <string>hintSet0000</string>
+            <key>stems</key>
+            <array>
+              <string>hstem -10 197</string>
+              <string>vstem 30 207</string>
+            </array>
+          </dict>
+          <dict>
+            <key>pointTag</key>
+            <string>hintSet0004</string>
+            <key>stems</key>
+            <array>
+              <string>hstem 11 -21</string>
+              <string>vstem 30 207</string>
+            </array>
+          </dict>
+        </array>
+      </dict>
     </dict>
   </lib>
 </glyph>
-```
-
-  [advance]: #advance
-  [unicode]: #unicode
-  [note]: #note
-  [image]: #image
-  [guideline]: #guideline
-  [anchor]: #anchor
-  [outline]: #outline
-  [lib]: #lib
-  [color definition]: conventions.html#colors
-  [layerinfo.plist]: glyphs.html#layerinfo
-  [conventions]: conventions.html#identifiers
-  [component]: #component
-  [contour]: #contour
-  [point]: #point
-  [XML Property List]: conventions.html#propertylist
-  [reverse domain naming scheme]: conventions.html#reversedomain
-  [data directory]: data.html
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -336,23 +336,32 @@ This key provides a dict defining a set of PostScript hints for a glyph. The key
 
 | key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 |----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| pointTag | string          | unique point name. Must match a point name attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| pointTag | string          | unique point name. Must match a point 'name' attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
 
-*Hint ID computation.* The glyph is flattened to a single set of contours, with
-all transformations. The contours are converted to a string by iterating through
-all the points. For each point in each contour, the GLIF point type is appended,
-then the x and y value are converted to decimal strings and appended; white
-space is omitted. Any contour with a length of less than 2 is skipped.
+*Hint ID computation.* The hash string is initialized with the width value as a
+decimal string, with the prefix w'. The glyph outline element is converted to a
+string by iterating through all the child elements.
 
-For each component, the hash function is applied to the component glyph, and the
-hash string for the component glyph is then appended to the hash string for the
-parent glyph.
+If the child is a contour element, it is converted to a string and added to the
+hash string by iterating through all the point elements. Any contour with a
+length of less than 2 is skipped. For each point, the point 'type' attribute, if
+present, is written; else a space is written. The x and y values are then
+written as decimal strings separated by a comma. The x and y values are rounded
+to a precision of no more than 3 decimal places.
+
+If the child is a component element, first the transform values are written, if
+any. These are written by writing 't' followed by the comma-separated decimal
+values of the transform attributes in the following order: ["xScale", "xyScale",
+"yxScale","yScale", "xOffset", "yOffset"]. The letter 'h' is then written,
+followed by the hash ID for the component glyph. The four scale values will be
+rounded to a precision of 8 decimal places, and the offset values will be
+rounded to a precision of at most 3 decimal places.
 
 Once the hash string is built, it is used as is for the Hint ID if it is less
 than 128 characters. Otherwise, a SHA 512 hash is computed, and this is used as
-the Hint ID for the hint dict.
-
+the Hint ID for the hint dict. The SHA 512 hash is written with lowercase
+hexidecimal digits.
 
 ### Example
 
@@ -387,49 +396,31 @@ the Hint ID for the hint dict.
       <key>public.markColor</key>
       <string>1,0,0,0.5</string>
       <key>public.postscript.hints</key>
-    <dict>
-        <key>formatVersion<key><string>1</string>
-        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
-      <key>hintSetList</key>
-      <array>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0000</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0005</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 454 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0016</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-      </array>
-    </dict>
+      <dict>
+        <key>formatVersion</key><string>1</string>
+        <key>id</key><string>w268c237,88 237,152 193,187c134,187 74,187 30,150c30,88 30,23 74,-10c134,-10 193,-10 237,25</string>
+        <key>hintSetList</key>
+        <array>
+          <dict>
+            <key>pointTag</key>
+            <string>hintSet0000</string>
+            <key>stems</key>
+            <array>
+              <string>hstem -10 197</string>
+              <string>vstem 30 207</string>
+            </array>
+          </dict>
+          <dict>
+            <key>pointTag</key>
+            <string>hintSet0004</string>
+            <key>stems</key>
+            <array>
+              <string>hstem 11 -21</string>
+              <string>vstem 30 207</string>
+            </array>
+          </dict>
+        </array>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -319,6 +319,41 @@ This key is used for representing the "mark" color seen in various font editors.
 
 This key is used for representing the "vertical origin" 'y' coordinate used for vertical layout. The value for the key must be an integer or float. This data is optional. Authoring tools can use this data and the advance element's `height` attribute to create the VORG and vmtx tables.
 
+#### public.postscript.hints
+
+This key provides a dict defining a set of PostScript hints for a glyph. The key is optional. Note that the set of hints become invalid whenever the outline is edited so as to change point types or coordinates. Rather than requiring all editing apps to remove hints whenever the outline is changed, the hint dict "id" is provided so that a third party can see if the current outline differs from what was present when the hints were last derived. If the hash for the current outline differs from the hint dict "id" value, then the hints are invalid for the current outline, and should be discarded.
+
+#### Hint Dict
+
+| key         | value type | description                                                                                                                                                                                                                                                  |
+|-------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| formatVersion    | string     | format version. Currently "1", the first public version.                                                                                                                                                               |
+| id          | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
+| hintSetList | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
+| flexList    | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
+
+#### Hint Set
+
+| key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| pointTag | string          | unique point name. Must match a point name attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
+
+*Hint ID computation.* The glyph is flattened to a single set of contours, with
+all transformations. The contours are converted to a string by iterating through
+all the points. For each point in each contour, the GLIF point type is appended,
+then the x and y value are converted to decimal strings and appended; white
+space is omitted. Any contour with a length of less than 2 is skipped.
+
+For each component, the hash function is applied to the component glyph, and the
+hash string for the component glyph is then appended to the hash string for the
+parent glyph.
+
+Once the hash string is built, it is used as is for the Hint ID if it is less
+than 128 characters. Otherwise, a SHA 512 hash is computed, and this is used as
+the Hint ID for the hint dict.
+
+
 ### Example
 
 ```xml
@@ -351,6 +386,50 @@ This key is used for representing the "vertical origin" 'y' coordinate used for 
       <string>arbitrary custom data!</string>
       <key>public.markColor</key>
       <string>1,0,0,0.5</string>
+      <key>public.postscript.hints</key>
+    <dict>
+        <key>formatVersion<key><string>1</string>
+        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
+      <key>hintSetList</key>
+      <array>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0000</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0005</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 454 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0016</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+      </array>
+    </dict>
     </dict>
   </lib>
 </glyph>

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -3,22 +3,33 @@ layout: default
 title: Glyph Interchange Format
 ---
 
-The Glyph Interchange Format (GLIF) is a simple and clear XML representation of
-a single glyph. GLIF files typically have a *.glif* extension.
+| **File Format** | XML |
+
+The Glyph Interchange Format (GLIF) is a simple and clear XML representation of a single glyph. GLIF files typically have a *.glif* extension.
 
 The GLIF data follows this structure:
 
-{: .filediagram} - glyph - advance - unicode - note - image - guideline - anchor
-- outline - contour - point - component - lib
 
-Specification
--------------
+{: .filediagram}
+- glyph
+- advance
+- unicode
+- note
+- image
+- guideline
+- anchor
+- outline
+  - contour
+    - point
+  - component
+- lib
 
-In all elements, where an attribute has a defined default value the attribute is
-optional unless otherwise stated. If the attribute is not defined, the value for
-the attribute is implicitly the default value.
+## Specification
 
-{: \#glyph } \#\#\# glyph: The top level element.
+In all elements, where an attribute has a defined default value the attribute is optional unless otherwise stated. If the attribute is not defined, the value for the attribute is implicitly the default value.
+
+{: #glyph }
+### glyph: The top level element.
 
 #### Attributes
 
@@ -27,28 +38,23 @@ the attribute is implicitly the default value.
 | name           | The name of the glyph. This must be at least one character long. Different font specifications, such as OpenType, often have their own glyph name restrictions. Authoring tools should not make assumptions about the validity of a glyph's name for a particular font specification. |
 | format         | The format version. 2 for this version.                                                                                                                                                                                                                                               |
 
-The `name` attribute has limited uses in this version. The *contents.plist* file
-maps glyph names to file names, and one of the reasons to do this is to avoid
-having to parse all files just to get at a list of available glyph names. When
-reading GLIF files, the `name` attribute should be ignored, since manual editing
-may have caused a mismatch with the glyph name as stored in *contents.plist*, as
-well as with the file name, which is an algorithmic transformation of the glyph
-name. This attribute may become more useful in future versions of GLIF.
+The `name` attribute has limited uses in this version. The *contents.plist* file maps glyph names to file names, and one of the reasons to do this is to avoid having to parse all files just to get at a list of available glyph names. When reading GLIF files, the `name` attribute should be ignored, since manual editing may have caused a mismatch with the glyph name as stored in *contents.plist*, as well as with the file name, which is an algorithmic transformation of the glyph name. This attribute may become more useful in future versions of GLIF.
 
 #### Child Elements
 
-| element name            | description                    |
-|-------------------------|--------------------------------|
-| [advance](#advance)     | May occur at most once.        |
-| [unicode](#unicode)     | May occur any number of times. |
-| [note](#note)           | May occur at most once.        |
-| [image](#image)         | May occur at most once.        |
-| [guideline](#guideline) | May occur any number of times. |
-| [anchor](#anchor)       | May occur any number of times. |
-| [outline](#outline)     | May occur at most once.        |
-| [lib](#lib)             | May occur at most once.        |
+| element name | description                    |
+|--------------|--------------------------------|
+| [advance]    | May occur at most once.        |
+| [unicode]    | May occur any number of times. |
+| [note]       | May occur at most once.        |
+| [image]      | May occur at most once.        |
+| [guideline]  | May occur any number of times. |
+| [anchor]     | May occur any number of times. |
+| [outline]    | May occur at most once.        |
+| [lib]        | May occur at most once.        |
 
-{: \#advance } \#\#\# advance: Horizontal and vertical metrics.
+{: #advance }
+### advance: Horizontal and vertical metrics.
 
 #### Attributes
 
@@ -61,11 +67,12 @@ name. This attribute may become more useful in future versions of GLIF.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <advance width="400" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-{: \#unicode } \#\#\# unicode: Unicode code point.
+{: #unicode }
+### unicode: Unicode code point.
 
 #### Attributes
 
@@ -75,41 +82,35 @@ name. This attribute may become more useful in future versions of GLIF.
 
 #### This element has no child elements.
 
-The first occurrence of this element defines the primary Unicode value for this
-glyph.
+The first occurrence of this element defines the primary Unicode value for this glyph.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <unicode hex="0041" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-{: \#image } \#\#\# image: An image reference.
+{: #image }
+### image: An image reference.
 
-This optional element represents an image element in a glyph. It may occur at
-most once. The image should always be considered to be *behind* the outline
-element.
+This optional element represents an image element in a glyph. It may occur at most once. The image should always be considered to be *behind* the outline element.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                             | default value |
-|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| fileName       | string           | The image file name, including any file extension, not an absolute or relative path in the file system.                                                 | None          |
-| xScale         | integer or float | See below.                                                                                                                                              | 1             |
-| xyScale        | integer or float | See below.                                                                                                                                              | 0             |
-| yxScale        | integer or float | See below.                                                                                                                                              | 0             |
-| yScale         | integer or float | See below.                                                                                                                                              | 1             |
-| xOffset        | integer or float | See below.                                                                                                                                              | 0             |
-| yOffset        | integer or float | See below.                                                                                                                                              | 0             |
-| color          | string           | The color that should be applied to the image. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional. | no color      |
+| attribute name | data type        | description                                                                                                                    | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------|
+| fileName       | string           | The image file name, including any file extension, not an absolute or relative path in the file system.                        | None          |
+| xScale         | integer or float | See below.                                                                                                                     | 1             |
+| xyScale        | integer or float | See below.                                                                                                                     | 0             |
+| yxScale        | integer or float | See below.                                                                                                                     | 0             |
+| yScale         | integer or float | See below.                                                                                                                     | 1             |
+| xOffset        | integer or float | See below.                                                                                                                     | 0             |
+| yOffset        | integer or float | See below.                                                                                                                     | 0             |
+| color          | string           | The color that should be applied to the image. The format follows the [color definition] standard. This attribute is optional. | no color      |
 
-`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that
-order form an Affine transformation matrix, to be used to transform the image.
-The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
+`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that order form an Affine transformation matrix, to be used to transform the image. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
 
-One image width unit equals one horizontal font unit and one image height unit
-equals one vertical font unit **before** `xScale, xyScale, yxScale, yScale,
-xOffset, yOffset` are applied.
+One image width unit equals one horizontal font unit and one image height unit equals one vertical font unit **before** `xScale, xyScale, yxScale, yScale, xOffset, yOffset` are applied.
 
 #### This element has no child elements.
 
@@ -119,155 +120,142 @@ All images must be in Portable Network Graphics (PNG) format.
 
 #### Coloring Images
 
-There are two places that the color for an image can be defined: the color
-attribute of the image element and the `color` defined in
-[layerinfo.plist](glyphs.html#layerinfo). The color defined in the image
-element's color attribute always takes precedence. If that is not defined and
-the `color` is defined for the layer, the layer's `color` should be used. If
-both of these are undefined, the image's colors, without modification, should be
-used unless an authoring tool has a default color for images. If a color is to
-be applied, the authoring tool should convert the image to grayscale and then
-apply the color. This modified version of the image must not be saved into the
-images directory.
+There are two places that the color for an image can be defined: the color attribute of the image element and the `color` defined in [layerinfo.plist]. The color defined in the image element's color attribute always takes precedence. If that is not defined and the `color` is defined for the layer, the layer's `color` should be used. If both of these are undefined, the image's colors, without modification, should be used unless an authoring tool has a default color for images. If a color is to be applied, the authoring tool should convert the image to grayscale and then apply the color. This modified version of the image must not be saved into the images directory.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <image fileName="Sketch 1.png" xOffset="100" yOffset="200"
     xScale=".75" yScale=".75" color="1,0,0,.5" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{: \#guideline } \#\#\# guideline: A reference guideline.
+```
+
+{: #guideline }
+### guideline: A reference guideline.
 
 This element may occur any number of times.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate. Optional if `y` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | None          |
-| y              | integer or float | The 'y' coordinate. Optional if `x` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | None          |
-| angle          | integer or float | The angle of the guideline. This must be an angle between 0 and 360 degrees in a clockwise direction from the horizontal. If `x` or `y` are not specified, `angle` must not be specified. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | None          |
-| name           | string           | An arbitrary name for the guideline. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | no name       |
-| color          | string           | The color that should be applied to the guideline. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | no color      |
-| identifier     | string           | Unique identifier for the guideline. This attribute is not required and should only be added to guidelines as needed. However, once an identifier has been assigned to a guideline it must not be unnecessarily removed or changed. Identifiers may be changed in incoming guidelines during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than guidelines) in the glyph that the guideline belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate. Optional if `y` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None          |
+| y              | integer or float | The 'y' coordinate. Optional if `x` is provided and `angle` is not provided. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None          |
+| angle          | integer or float | The angle of the guideline. This must be an angle between 0 and 360 degrees in a clockwise direction from the horizontal. If `x` or `y` are not specified, `angle` must not be specified. See below for details.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | None          |
+| name           | string           | An arbitrary name for the guideline. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no name       |
+| color          | string           | The color that should be applied to the guideline. The format follows the [color definition] standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | no color      |
+| identifier     | string           | Unique identifier for the guideline. This attribute is not required and should only be added to guidelines as needed. However, once an identifier has been assigned to a guideline it must not be unnecessarily removed or changed. Identifiers may be changed in incoming guidelines during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than guidelines) in the glyph that the guideline belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
 
-The guideline extends along `angle` to infinity in both directions out of the
-point defined by `x` and `y`. If `y` and `angle` are omitted, the element
-represents a vertical guideline. If `x` and `angle` are omitted, the element
-represents a horizontal guideline.
+The guideline extends along `angle` to infinity in both directions out of the point defined by `x` and `y`. If `y` and `angle` are omitted, the element represents a vertical guideline. If `x` and `angle` are omitted, the element represents a horizontal guideline.
 
 #### This element has no child elements.
 
-{: \#anchor } \#\#\# anchor: A reference position.
+{: #anchor }
+### anchor: A reference position.
 
 This element may occur any number of times.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | default value |
-|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | None          |
-| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | None          |
-| name           | string           | An arbitrary name for the anchor. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no name       |
-| color          | string           | The color that should be applied to the anchor. The format follows the [color definition](conventions.html#colors) standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | no color      |
-| identifier     | string           | Unique identifier for the anchor. This attribute is not required and should only be added to anchors as needed. However, once an identifier has been assigned to an anchor it must not be unnecessarily removed or changed. Identifiers may be changed in incoming anchors during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than anchors) in the glyph that the anchor belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | default value |
+|----------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | None          |
+| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | None          |
+| name           | string           | An arbitrary name for the anchor. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | no name       |
+| color          | string           | The color that should be applied to the anchor. The format follows the [color definition] standard. This attribute is optional.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | no color      |
+| identifier     | string           | Unique identifier for the anchor. This attribute is not required and should only be added to anchors as needed. However, once an identifier has been assigned to an anchor it must not be unnecessarily removed or changed. Identifiers may be changed in incoming anchors during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than anchors) in the glyph that the anchor belongs to but it is not required to be unique among the identifiers assigned in other glyphs or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
 
 #### This element has no child elements.
 
 #### Converting implied anchors in GLIF 1 to GLIF 2 anchor elements
 
-In GLIF 1 there was no official anchor element. Anchors were unofficially but
-widely supported through the use of a contour containing only one "move" point.
-For example:
+In GLIF 1 there was no official anchor element. Anchors were unofficially but widely supported through the use of a contour containing only one "move" point. For example:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <contour>
   <point x="250" y="650" type="move" name="top"/>
 </contour>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Authoring tools may convert instances of contours like this to anchor elements
-when converting GLIF 1 to GLIF 2. The required `x` and `y` and optional `name`
-attributes directly map to the same attributes of the anchor element.
+```
 
-{: \#outline } \#\#\# outline: Outline description.
+Authoring tools may convert instances of contours like this to anchor elements when converting GLIF 1 to GLIF 2. The required `x` and `y` and optional `name` attributes directly map to the same attributes of the anchor element.
+
+{: #outline }
+### outline: Outline description.
 
 #### This element has no attributes.
 
 #### Child Elements
 
-| element name            | description                    |
-|-------------------------|--------------------------------|
-| [component](#component) | May occur any number of times. |
-| [contour](#contour)     | May occur any number of times. |
+| element name | description                    |
+|--------------|--------------------------------|
+| [component]  | May occur any number of times. |
+| [contour]    | May occur any number of times. |
 
-{: \#component } \#\#\# component: Insert another glyph as part of the outline.
+{: #component }
+### component: Insert another glyph as part of the outline.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| base           | string           | Name of the base glyph                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | None          |
-| xScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1             |
-| xyScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
-| yxScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
-| yScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 1             |
-| xOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
-| yOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | 0             |
-| identifier     | string           | Unique identifier for the component. This attribute is not required and should only be added to components as needed. However, once an identifier has been assigned to a component it must not be unnecessarily removed or changed. Identifiers may be changed in incoming components during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than components) in the glyph that the component belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| base           | string           | Name of the base glyph                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | None          |
+| xScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1             |
+| xyScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
+| yxScale        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
+| yScale         | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 1             |
+| xOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
+| yOffset        | integer or float | See below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | 0             |
+| identifier     | string           | Unique identifier for the component. This attribute is not required and should only be added to components as needed. However, once an identifier has been assigned to a component it must not be unnecessarily removed or changed. Identifiers may be changed in incoming components during editing operations such as "paste," but they should be maintained unless a duplicate identifier will be created. The identifier value must be unique within all identifiers (including identifiers for elements other than components) in the glyph that the component belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
 
-`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that
-order form an Affine transformation matrix, to be used to transform the base
-glyph. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
+`xScale, xyScale, yxScale, yScale, xOffset, yOffset` taken together in that order form an Affine transformation matrix, to be used to transform the base glyph. The default matrix is `[1 0 0 1 0 0]`, the identity transformation.
 
-The base glyph referenced by a component may contain components. The base glyph
-must not create a circular reference to the glyph that contains the component.
-Components must only reference glyphs within the same layer that the component
-belongs to.
+The base glyph referenced by a component may contain components. The base glyph must not create a circular reference to the glyph that contains the component. Components must only reference glyphs within the same layer that the component belongs to.
 
 #### This element has no child elements.
 
 #### Example
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <component base="A" xOffset="100" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-{: \#contour } \#\#\# contour: Contour description.
+{: #contour }
+### contour: Contour description.
 
 #### Attributes
 
-| attribute name | data type | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | default value |
-|----------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| identifier     | string    | Unique identifier for the component. This attribute is not required and should only be added to contours as needed. However, once an identifier has been assigned to a contour it must not be unnecessarily removed or changed. Identifiers may be changed in incoming contours during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than contours) in the glyph that the contour belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
+| attribute name | data type | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
+|----------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| identifier     | string    | Unique identifier for the component. This attribute is not required and should only be added to contours as needed. However, once an identifier has been assigned to a contour it must not be unnecessarily removed or changed. Identifiers may be changed in incoming contours during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than contours) in the glyph that the contour belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
 
 #### Child Elements
 
-| element name    | description                    |
-|-----------------|--------------------------------|
-| [point](#point) | May occur any number of times. |
+| element name | description                    |
+|--------------|--------------------------------|
+| [point]      | May occur any number of times. |
 
-There is no requirement that a contour contain an on-curve point. If a contour
-contains only off-curve points the contour must be treated as a quadratic curve.
+There is no requirement that a contour contain an on-curve point. If a contour contains only off-curve points the contour must be treated as a quadratic curve.
 
-{: \#point } \#\#\# point: An attributed coordinate pair.
+{: #point }
+### point: An attributed coordinate pair.
 
 #### Attributes
 
-| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | default value |
-|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | None          |
-| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | None          |
-| type           | string           | The point and/or segment type. The options are detailed below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | offcurve      |
-| smooth         | string           | This attribute must only be given when `type` indicates the point is on-curve. When set to `yes`, it signifies that a smooth curvature should be maintained at this point, either as a `curve point` or a `tangent point` in Fontographer terms. This attribute may be set for all point types except `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | no            |
-| name           | string           | Arbitrary name or label for this point. The name does not have to be unique within a contour, nor within an outline.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | no name       |
-| identifier     | string           | Unique identifier for the point. This attribute is not required and should only be added to points as needed. However, once an identifier has been assigned to a point it must not be unnecessarily removed or changed. Identifiers may be changed in incoming points during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than poinys) in the glyph that the point belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions](conventions.html#identifiers). | no identifier |
+| attribute name | data type        | description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | default value |
+|----------------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| x              | integer or float | The 'x' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | None          |
+| y              | integer or float | The 'y' coordinate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | None          |
+| type           | string           | The point and/or segment type. The options are detailed below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | offcurve      |
+| smooth         | string           | This attribute must only be given when `type` indicates the point is on-curve. When set to `yes`, it signifies that a smooth curvature should be maintained at this point, either as a `curve point` or a `tangent point` in Fontographer terms. This attribute may be set for all point types except `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | no            |
+| name           | string           | Arbitrary name or label for this point. The name does not have to be unique within a contour, nor within an outline.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | no name       |
+| identifier     | string           | Unique identifier for the point. This attribute is not required and should only be added to points as needed. However, once an identifier has been assigned to a point it must not be unnecessarily removed or changed. Identifiers may be changed in incoming points during editing operations such as "paste" and component decomposition, but they should be maintained unless a duplicate identifier will be created. Identifiers should also be retained when possible during outline manipulation operations such as path direction changes and remove overlap. The identifier value must be unique within all identifiers (including identifiers for elements other than poinys) in the glyph that the point belongs to but it is not required to be unique among the identifiers assigned in other glyphs, in any layerinfo.plist or in fontinfo.plist. The identifier specification is detailed in the [conventions]. | no identifier |
 
 ##### Point Types
 
-| move     | A point of this type must be the first in a `contour`. The reverse is not true: a `contour` does not necessarily start with a `move` point. When a `contour` **does** start with a `move` point, it signifies the beginning of an **open** contour. A **closed** contour does **not** start with a `move` and is defined as a cyclic list of points, with no predominant start point. There is always a *next point* and a *previous point*. For this purpose the list of points can be seen as endless in both directions. The actual list of points can be rotated arbitrarily (by removing the first N points and appending them at the end) while still describing the same outline. |
+|          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 |----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| move     | A point of this type must be the first in a `contour`. The reverse is not true: a `contour` does not necessarily start with a `move` point. When a `contour` **does** start with a `move` point, it signifies the beginning of an **open** contour. A **closed** contour does **not** start with a `move` and is defined as a cyclic list of points, with no predominant start point. There is always a *next point* and a *previous point*. For this purpose the list of points can be seen as endless in both directions. The actual list of points can be rotated arbitrarily (by removing the first N points and appending them at the end) while still describing the same outline. |
 | line     | Draw a straight line from the previous point to this point. The previous point must be a `move`, a `line`, a `curve` or a `qcurve`. It must not be an `offcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | offcurve | This point is part of a curve segment that goes up to the next point that is either a `curve` or a `qcurve`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | curve    | Draw a cubic bezier curve from the last non-*offcurve* point to this point. The number of *offcurve* points can be zero, one or two. If the number of `offcurve` points is zero, a straight line is drawn. If it is one, a quadratic curve is drawn. If it is two, a regular cubic bezier is drawn.                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -279,128 +267,96 @@ contains only off-curve points the contour must be treated as a quadratic curve.
 
 move point:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <point x="433" y="371" type="move" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 line point:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <point x="433" y="371" type="line" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 offcurve point:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <point x="433" y="366" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 curve point:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <point x="441" y="363" type="curve" smooth="yes" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 qcurve point:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <point x="441" y="363" type="qcurve" />
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-{: \#note } \#\#\# note: Note about the glyph.
+{: #note }
+### note: Note about the glyph.
 
-This element is a place for the user to define arbitrary text about the glyph.
-There is no standardized structure for the note apart from that it being the
-content of the note element.
+This element is a place for the user to define arbitrary text about the glyph. There is no standardized structure for the note apart from that it being the content of the note element.
 
-{: \#lib } \#\#\# lib: Custom data storage.
+{: #lib }
+### lib: Custom data storage.
 
-This element is a place to store authoring tool specific, user specific or
-otherwise arbitrary data for the glyph. lib mus have one child element that is
-structure as a dictionary formatted as an [XML Property
-List](conventions.html#propertylist). This element may occur at most once. In
-order to prevent conflicts in the lib, keys in the top level should follow a
-[reverse domain naming scheme](conventions.html#reversedomain). The pattern
-"public.\*", where \* represents an arbitrary string of one or more characters,
-is reserved for use in standardized lib keys. It is recommended that the data
-stored as a value be as shallow as possible.
+This element is a place to store authoring tool specific, user specific or otherwise arbitrary data for the glyph. lib mus have one child element that is structure as a dictionary formatted as an [XML Property List]. This element may occur at most once. In order to prevent conflicts in the lib, keys in the top level should follow a [reverse domain naming scheme]. The pattern "public.\*", where \* represents an arbitrary string of one or more characters, is reserved for use in standardized lib keys. It is recommended that the data stored as a value be as shallow as possible.
 
-Data that is too complex or too large for lib can be stored in the [data
-directory](data.html).
+Data that is too complex or too large for lib can be stored in the [data directory].
 
 #### Common Key Registry
 
-The following is a registry of public lib keys that map to functionality that is
-often seen in font editing applications but is not suitable for storage
-elsewhere in this particular version of the UFO.
+The following is a registry of public lib keys that map to functionality that is often seen in font editing applications but is not suitable for storage elsewhere in this particular version of the UFO.
 
 ##### public.markColor
 
-This key is used for representing the "mark" color seen in various font editors.
-The value for the key must be a string following the [color
-definition](conventions.html#colors) standard. This data is optional.
+This key is used for representing the "mark" color seen in various font editors. The value for the key must be a string following the [color definition] standard. This data is optional.
 
 ##### public.verticalOrigin
 
-This key is used for representing the "vertical origin" 'y' coordinate used for
-vertical layout. The value for the key must be an integer or float. This data is
-optional. Authoring tools can use this data and the advance element's `height`
-attribute to create the VORG and vmtx tables.
+This key is used for representing the "vertical origin" 'y' coordinate used for vertical layout. The value for the key must be an integer or float. This data is optional. Authoring tools can use this data and the advance element's `height` attribute to create the VORG and vmtx tables.
 
 #### public.postscript.hints
 
-This key provides a dict defining a set of PostScript hints for a glyph. The key
-is optional. Note that the set of hints become invalid whenever the outline is
-edited so as to change point types or coordinates. Rather than requiring all
-editing apps to remove hints whenever the outline is changed, the hint dict "id"
-is provided so that a third party can see if the current outline differs from
-what was present when the hints were last derived. If the hash for the current
-outline differs from the hint dict "id" value, then the hints are invalid for
-the current outline, and should be discarded.
+This key provides a dict defining a set of PostScript hints for a glyph. The key is optional. Note that the set of hints become invalid whenever the outline is edited so as to change point types or coordinates. Rather than requiring all editing apps to remove hints whenever the outline is changed, the hint dict "id" is provided so that a third party can see if the current outline differs from what was present when the hints were last derived. If the hash for the current outline differs from the hint dict "id" value, then the hints are invalid for the current outline, and should be discarded.
 
 #### Hint Dict
 
-| key           | value type | description                                                                                                                                                                                                                                                  |
-|---------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| formatVersion | string     | format version. Currently "1", the first public version.                                                                                                                                                                                                     |
-| id            | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
-| hintSetList   | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
-| flexList      | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
+| key         | value type | description                                                                                                                                                                                                                                                  |
+|-------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| formatVersion    | string     | format version. Currently "1", the first public version.                                                                                                                                                               |
+| id          | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
+| hintSetList | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
+| flexList    | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
 
 #### Hint Set
 
 | key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 |----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| pointTag | string          | unique point name. Must match a point ‘name' attribute.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| pointTag | string          | unique point name. Must match a point name attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
 
-*Hint ID computation.* The hash string is initialized with the width value as a
-decimal string, with the prefix w'. The glyph outline element is converted to a
-string by iterating through all the child elements.
+*Hint ID computation.* The glyph is flattened to a single set of contours, with
+all transformations. The contours are converted to a string by iterating through
+all the points. For each point in each contour, the GLIF point type is appended,
+then the x and y value are converted to decimal strings and appended; white
+space is omitted. Any contour with a length of less than 2 is skipped.
 
-If the child is a contour element, it is converted to a string and added to the
-hash string by iterating through all the point elements. Any contour with a
-length of less than 2 is skipped. For each point, the point 'type' attribute, if
-present, is written; else a space is written. The x and y values are then
-written as decimal strings separated by a comma. The x and y values are rounded
-to a precision of no more than 3 decimal places.
-
-If the child is a component element, first the transform values are written, if
-any. These are written by writing 't' followed by the comma-separated decimal
-values of the transform attributes in the following order: ["xScale", "xyScale",
-"yxScale","yScale", "xOffset", "yOffset"]. The letter 'h' is then written,
-followed by the hash ID for the component glyph. The four scale values will be
-rounded to a precision of 8 decimal places, and the offset values will be
-rounded to a precision of at most 3 decimal places.
+For each component, the hash function is applied to the component glyph, and the
+hash string for the component glyph is then appended to the hash string for the
+parent glyph.
 
 Once the hash string is built, it is used as is for the Hint ID if it is less
 than 128 characters. Otherwise, a SHA 512 hash is computed, and this is used as
-the Hint ID for the hint dict. The SHA 512 hash is written with lowercase
-hexidecimal digits.
+the Hint ID for the hint dict.
+
 
 ### Example
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ xml
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="period" format="2">
   <advance width="268"/>
@@ -431,32 +387,68 @@ hexidecimal digits.
       <key>public.markColor</key>
       <string>1,0,0,0.5</string>
       <key>public.postscript.hints</key>
-      <dict>
-        <key>formatVersion</key><string>1</string>
-        <key>id</key><string>w268c237,88 237,152 193,187c134,187 74,187 30,150c30,88 30,23 74,-10c134,-10 193,-10 237,25</string>
-        <key>hintSetList</key>
-        <array>
-          <dict>
-            <key>pointTag</key>
-            <string>hintSet0000</string>
-            <key>stems</key>
-            <array>
-              <string>hstem -10 197</string>
-              <string>vstem 30 207</string>
-            </array>
-          </dict>
-          <dict>
-            <key>pointTag</key>
-            <string>hintSet0004</string>
-            <key>stems</key>
-            <array>
-              <string>hstem 11 -21</string>
-              <string>vstem 30 207</string>
-            </array>
-          </dict>
-        </array>
-      </dict>
+    <dict>
+        <key>formatVersion<key><string>1</string>
+        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
+      <key>hintSetList</key>
+      <array>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0000</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0005</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 454 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0016</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+      </array>
+    </dict>
     </dict>
   </lib>
 </glyph>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+  [advance]: #advance
+  [unicode]: #unicode
+  [note]: #note
+  [image]: #image
+  [guideline]: #guideline
+  [anchor]: #anchor
+  [outline]: #outline
+  [lib]: #lib
+  [color definition]: conventions.html#colors
+  [layerinfo.plist]: glyphs.html#layerinfo
+  [conventions]: conventions.html#identifiers
+  [component]: #component
+  [contour]: #contour
+  [point]: #point
+  [XML Property List]: conventions.html#propertylist
+  [reverse domain naming scheme]: conventions.html#reversedomain
+  [data directory]: data.html

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -29,6 +29,49 @@ This defines a preferred glyph name to Postscript glyph name mapping for glyphs 
 
 The mapping is stored as a dictionary with glyphs names as keys and Postscript glyph names as values. Both keys and values must be strings. The values must conform to the Postscript glyph naming specification. The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font. If a glyph's name is not defined in this mapping, the glyph's name should be used as the Postscript name.
 
+#### public.postscript.hints
+
+This key provides a mapping from glyph names to sets of PostScript hints for the
+default glyph layer. The mapping is stored as a dictionary with glyph names as
+keys and Postscript hint sets as values. If a glyph's name is missing from the
+mapping, then there are no Postscript hints for that glyph.
+
+Any mapping from glyph names to sets of PostScript hints for any layer other
+than the default layer is stored in the layerinfo.plist for the layer, using the
+same key.
+
+#### Hint Dict
+
+| key         | value type | description                                                                                                                                                                                                                                                  |
+|-------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id          | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
+| hintSetList | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
+| flexList    | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
+
+#### Hint Set
+
+| key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| pointTag | string          | unique point name.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
+
+*Hint ID computation.* The glyph is flattened to a single set of contours, with
+all transformations. The contours are converted to a string by iterating through
+all the points. For each point in each contour, the GLIF point type is appended,
+then the x and y value are converted to decimal strings and appended; white
+space is omitted. Any contour with a length of less than 2 is skipped. The glyph
+width is pre-pended after being converted to a decimal string.
+
+For each component, the string "base:" is appended to the string. The hash
+function is then applied to the component glyph, and the hash string for the
+component glyph is then appended to the hash string for the parent glyph.
+
+Once the hash string is built, it is used as is for the Hint ID if it is less
+than 128 characters. Otherwise, a SHA 512 hash is computer, and this is used as
+the Hint ID for the hint dict.
+
+ 
+
 ### Example
 
 ```xml
@@ -45,7 +88,50 @@ The mapping is stored as a dictionary with glyphs names as keys and Postscript g
     <string>C</string>
     <string>B</string>
   </array>
-</dict>
+  <key>public.postscript.hints</key>
+    <dict>
+        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
+      <key>hintSetList</key>
+      <array>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0000</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0005</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 454 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+        <dict>
+          <key>pointTag</key>
+          <string>hintSet0016</string>
+          <key>stems</key>
+          <array>
+            <string>hstem 0 28</string>
+            <string>hstem 338 28</string>
+            <string>hstem 632 28</string>
+            <string>hstem 100 32</string>
+            <string>hstem 496 32</string>
+          </array>
+        </dict>
+      </array>
+    </dict>
+  </dict>
 </plist>
 ```
 

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -29,49 +29,6 @@ This defines a preferred glyph name to Postscript glyph name mapping for glyphs 
 
 The mapping is stored as a dictionary with glyphs names as keys and Postscript glyph names as values. Both keys and values must be strings. The values must conform to the Postscript glyph naming specification. The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font. If a glyph's name is not defined in this mapping, the glyph's name should be used as the Postscript name.
 
-#### public.postscript.hints
-
-This key provides a mapping from glyph names to sets of PostScript hints for the
-default glyph layer. The mapping is stored as a dictionary with glyph names as
-keys and Postscript hint sets as values. If a glyph's name is missing from the
-mapping, then there are no Postscript hints for that glyph.
-
-Any mapping from glyph names to sets of PostScript hints for any layer other
-than the default layer is stored in the layerinfo.plist for the layer, using the
-same key.
-
-#### Hint Dict
-
-| key         | value type | description                                                                                                                                                                                                                                                  |
-|-------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id          | string     | Hash of glyph outlines. This is computed when the glyph is hinted. It is used to determine if the glyph outline has been changed since the glyph was hinted: if it has, then the hint dict for the glyph should be deleted. See "Hint ID Computation" below. |
-| hintSetList | list       | List of hint sets. A hint set is a dict containing a list of hints, and a unique point name which identifies the point after which the hint set is applied.                                                                                                  |
-| flexList    | string     | List of unique point names. Each point name identifies the point at which a flex hint starts.                                                                                                                                                                |
-
-#### Hint Set
-
-| key      | value type      | description                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-|----------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| pointTag | string          | unique point name.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| stems    | list of strings | list of stem strings. Each stem string starts with either 'hstem" or "vstem" and is a followed by a series of white-space delimited stem coordinate values. A stem coordinate value is an absolute coordinate. There must be an even number of stem coordinates: each pair of values defines a lower and upper edge of a stem hint. The stems must be sorted in ascending order of lower edge values. 'hstem' strings must be sorted before 'vstem' strings. |
-
-*Hint ID computation.* The glyph is flattened to a single set of contours, with
-all transformations. The contours are converted to a string by iterating through
-all the points. For each point in each contour, the GLIF point type is appended,
-then the x and y value are converted to decimal strings and appended; white
-space is omitted. Any contour with a length of less than 2 is skipped. The glyph
-width is pre-pended after being converted to a decimal string.
-
-For each component, the string "base:" is appended to the string. The hash
-function is then applied to the component glyph, and the hash string for the
-component glyph is then appended to the hash string for the parent glyph.
-
-Once the hash string is built, it is used as is for the Hint ID if it is less
-than 128 characters. Otherwise, a SHA 512 hash is computer, and this is used as
-the Hint ID for the hint dict.
-
- 
-
 ### Example
 
 ```xml
@@ -88,50 +45,7 @@ the Hint ID for the hint dict.
     <string>C</string>
     <string>B</string>
   </array>
-  <key>public.postscript.hints</key>
-    <dict>
-        <key>id</key><string>64bf4987f05ced2a50195f971cd924984047eb1d79c8c43e6a0054f59cc85dea23a49deb20946a4ea84840534363f7a13cca31a81b1e7e33c832185173369086</string>
-      <key>hintSetList</key>
-      <array>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0000</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0005</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 454 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-        <dict>
-          <key>pointTag</key>
-          <string>hintSet0016</string>
-          <key>stems</key>
-          <array>
-            <string>hstem 0 28</string>
-            <string>hstem 338 28</string>
-            <string>hstem 632 28</string>
-            <string>hstem 100 32</string>
-            <string>hstem 496 32</string>
-          </array>
-        </dict>
-      </array>
-    </dict>
-  </dict>
+</dict>
 </plist>
 ```
 


### PR DESCRIPTION
First pass documentation, do not hesitate to edit. I propose changing the rules for creating the hint dict "id" value by dropping the "base:<component glyph name"  item when parsing a component glyph.