### PR TITLE
Document proposed public.skipExportGlyphs lib key

### DIFF
--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -52,7 +52,7 @@ This key is a list of glyph names used for representing glyphs that the user doe
 
 The handling of the feature file is undefined.
 
-This data is optional. A glyph name must only appear once and only glyph names that are in the font must be listed. An empty list or the absence of this key means that all glyphs are to be exported as-is with groups and kerning untouched.
+This data is optional. Glyph names must not occur more than once. The list may contain glyphs that are not in the font. An empty list or the absence of this key means that all glyphs are to be exported as-is with groups and kerning untouched.
 
 ### Example
 

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -41,6 +41,19 @@ This defines a preferred glyph name to Postscript glyph name mapping for glyphs 
 
 The mapping is stored as a dictionary with glyphs names as keys and Postscript glyph names as values. Both keys and values must be strings. The values must conform to the Postscript glyph naming specification. The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font. If a glyph's name is not defined in this mapping, the glyph's name should be used as the Postscript name.
 
+#### public.skipExportGlyphs
+
+This key is a list of glyph names used for representing glyphs that the user does not want exported to the final font file. The UFO compiler is expected to:
+
+1. Remove these glyphs before the compilation run.
+2. Decompose the listed glyphs everywhere they are used as components.
+3. Prune all groups of the listed glyphs, possibly leaving empty groups.
+4. Prune all kerning pairs that contain any of the listed glyphs.
+
+The handling of the feature file is undefined.
+
+This data is optional. A glyph name must only appear once and only glyph names that are in the font must be listed. An empty list or the absence of this key means that all glyphs are to be exported as-is with groups and kerning untouched.
+
 ### Example
 
 ```xml

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -47,8 +47,9 @@ This key is a list of glyph names used for representing glyphs that the user doe
 
 1. Remove these glyphs before the compilation run.
 2. Decompose the listed glyphs everywhere they are used as components.
-3. Prune all groups of the listed glyphs, possibly leaving empty groups.
-4. Prune all kerning pairs that contain any of the listed glyphs.
+3. Prune all groups of the listed glyphs. Subsequently empty groups must be removed.
+4. Prune all kerning pairs that contain any of the listed glyphs or now empty groups.
+5. Not modify the source UFO on disk. This is a compiler-internal process.
 
 The handling of the feature file is undefined.
 

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -45,8 +45,8 @@ The mapping is stored as a dictionary with glyphs names as keys and Postscript g
 
 This key is a list of glyph names used for representing glyphs that the user does not want exported to the final font file. The UFO compiler is expected to:
 
-1. Remove these glyphs before the compilation run.
-2. Decompose the listed glyphs everywhere they are used as components.
+1. Decompose the listed glyphs everywhere they are used as components.
+2. Remove these glyphs before the compilation run.
 3. Prune all groups of the listed glyphs. Subsequently empty groups must be removed.
 4. Prune all kerning pairs that contain any of the listed glyphs or now empty groups.
 5. Not modify the source UFO on disk. This is a compiler-internal process.


### PR DESCRIPTION
See https://github.com/unified-font-object/ufo-spec/issues/68.

I'm not sure it's necessary to impose set semantics on the list. Opinions?