### PR TITLE
Clarify that kerning groups may be empty

### DIFF
--- a/versions/ufo3/kerning.plist.md
+++ b/versions/ufo3/kerning.plist.md
@@ -12,7 +12,7 @@ This file contains horizontal kerning pairs for the font. This file is optional.
 
 The property list data consists of a dictionary at the top level. Keys are *first* member names and values are dictionaries. These dictionaries contain *second* member names as keys and kerning values, either integer or float, as the values.
 
-The kerning pair members are glyph names or group names. Group names used as the first member of a kerning pair must begin with the kerning group prefix defined in the [groups.plist specification]. Group names used as the second member of a kerning pair must begin with the kerning group prefix defined in the [groups.plist specification]. Glyphs or groups in the pairs are not required to be in the font.
+The kerning pair members are glyph names or group names. Group names used as the first member of a kerning pair must begin with the kerning group prefix defined in the [groups.plist specification]. Group names used as the second member of a kerning pair must begin with the kerning group prefix defined in the [groups.plist specification]. Glyphs or groups in the pairs are not required to be in the font. Groups may also be empty. It is the responsibility of the authoring tool to remove these from compiled fonts when needed.
 
 Kerning pairs that are not defined in kerning.plist implicitly have a value of "no kerning" or zero. Therefore any kerning pair that has a value of zero, unless it is a necessary value of an [exception], should not be stored in kerning.plist.
 

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -47,8 +47,8 @@ This key is a list of glyph names used for representing glyphs that the user doe
 
 1. Decompose the listed glyphs everywhere they are used as components.
 2. Remove these glyphs before the compilation run.
-3. Prune all groups of the listed glyphs. Subsequently empty groups must be removed.
-4. Prune all kerning pairs that contain any of the listed glyphs or now empty groups.
+3. Prune all groups of the listed glyphs.
+4. Prune all kerning pairs that contain any of the listed glyphs.
 5. Not modify the source UFO on disk. This is a compiler-internal process.
 
 The handling of the feature file is undefined.


### PR DESCRIPTION
This fell off https://github.com/unified-font-object/ufo-spec/pull/84.