### PR TITLE
Add public.truetype.instructions to lib.plist and glif

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -343,6 +343,18 @@ The following is a registry of public lib keys that map to functionality that is
 
 This key is used for representing the "mark" color seen in various font editors. The value for the key must be a string following the [color definition] standard. This data is optional.
 
+#### public.truetype.instructions
+
+This key provides a dict defining a set of TrueType instructions assembly code for a glyph. This data is optional.
+
+#### TrueType Instructions Dict
+| key           | value type | description                                                                                                                                                                                                                                                                                                                                                |
+|---------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| formatVersion | string     | Format version. Set to "1".                                                                                                                                                                                                                                                                                                                                |
+| id            | string     | Hash of glyph outlines which may have been processed by authoring tools. This is computed when the instructions dict is created or modified. It is used to determine if the glyph outlines have changed since the glyph was hinted: if it has, then the instructions for the glyph should not be used by authoring tools. See "Hint ID Computation" below. |
+| assembly      | string     | TrueType instructions assembly. The assembly is as represented with fontTools.                                                                                                                                                                                                                                                                             |
+
+
 ##### public.verticalOrigin
 
 This key is used for representing the "vertical origin" 'y' coordinate used for vertical layout. The value for the key must be an integer or float. This data is optional. Authoring tools can use this data and the advance element's `height` attribute to create the VORG and vmtx tables.

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -42,6 +42,24 @@ This defines a preferred glyph name to Postscript glyph name mapping for glyphs 
 
 The mapping is stored as a dictionary with glyphs names as keys and Postscript glyph names as values. Both keys and values must be strings. The values must conform to the Postscript glyph naming specification. The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font. If a glyph's name is not defined in this mapping, the glyph's name should be used as the Postscript name.
 
+#### public.truetype.instructions
+This key provides a dict defining TrueType instructions data.
+This data is optional.
+
+| key                   | value type | description                 |
+|-----------------------|------------|-----------------------------|
+| formatVersion         | string     | Format version. Set to "1". |
+| controlValue          | dict       | TrueType instructions control values as a dictionary of control values keyed by index. This is optional.                                          |
+| controlValueProgram   | string     | TrueType preprogram assembly as a string. The assembly is as represented by fontTools. This is optional.                                          |
+| fontProgram           | string     | TrueType font program assembly as a string. The assembly as represented by fontTools. This is optional.                                           |
+| maxFunctionDefs       | integer    | Number of function definitions, used by TrueType instructions, stored in the `maxp` in OpenType table as an integer. This is optional.            |
+| maxInstructionDefs    | integer    | Number of instruction definitions, used by TrueType instructions, stored in the `maxp` in OpenType table as an integer. This is optional.         |
+| maxStackElements      | integer    | Maximum stack depth, used by TrueType instructions, stored in the `maxp` in OpenType table as an integer. This is optional.                       |
+| maxStorage            | integer    | Maximum number of storage area locations, used by TrueType instructions, stored in the `maxp` in OpenType table. This is optional.                |
+| maxSizeOfInstructions | integer    | Maximum byte count for glyph instructions, used by TrueType instructions, stored in the `maxp` in OpenType table as an integer. This is optional. |
+| maxTwilightPoints     | integer    | Maximum points used in zone 0, stored in the `maxp` in OpenType table as an integer. This is optional.                                            |
+| maxZones              | integer    | Number of zones used by TrueType instructions, stored in the `maxp` in OpenType table as an integer. This is optional.                            |
+
 #### public.skipExportGlyphs
 
 This key is a list of glyph names used for representing glyphs that the user does not want exported to the final font file. The UFO compiler is expected to:


### PR DESCRIPTION
This fixes #93 "TrueType instructions in UFO" by adding `public.truetype.instructions` to lib.plist and glif.

In the glyph’s lib:
* `public.truetype.instructions` as a dict:
  * `formatVersion` string "1"
  * `id` string Hash of glyph outlines (similar to `public.postscript.hints` id)
  * `assembly` string TTX assembly

In a font’s lib:
* `public.truetype.instructions` as a dict:
  * `formatVersion` string "1"
  * `controlValue` as an dict of integers keyed by index, optional
  * `controlValueProgram` string TTX assembly, optional
  * `fontProgram` string TTX assembly, optional,
  * `maxStorage` integer, optional
  * `maxFunctionDefs` integer, optional
  * `maxInstructionDefs` integer, optional
  * `maxStackElements` integer, optional
  * `maxSizeOfInstructions` integer, optional
  * `maxZones` integer, optional
  * `maxTwilightPoints` integer, optional

The maxp data could in theory be computed at build time but it’s convenient to allow storing it.