### PR TITLE
rangeGaspBehavior bits SYMMETRIC_{GRIDFIT,SMOOTHING} are inverted

### DIFF
--- a/versions/ufo3/fontinfo.plist.md
+++ b/versions/ufo3/fontinfo.plist.md
@@ -92,8 +92,8 @@ The following bit numbers correspond to the matching bits in the OpenType gasp s
 |-------|-------------------------------------|
 | 0     | GASP\_GRIDFIT (0x0001)              |
 | 1     | GASP\_DOGRAY (0x0002)               |
-| 2     | GASP\_SYMMETRIC\_SMOOTHING (0x0004) |
-| 3     | GASP\_SYMMETRIC\_GRIDFIT (0x0008)   |
+| 2     | GASP\_SYMMETRIC\_GRIDFIT (0x0004)   |
+| 3     | GASP\_SYMMETRIC\_SMOOTHING (0x0008) |
 
 ##### Notes
 


### PR DESCRIPTION
@aaronbell discovered in https://github.com/fonttools/ufoLib2/pull/44 that the way UFO spec defines GASP behavior bits is incorrect according to the OpenType gasp spec:

https://docs.microsoft.com/en-us/typography/opentype/spec/gasp#gasp-table-formats

Do you we just fix this and pretend it never happened?
Or do we make the change in a new version of the spec (3.1 or 4)?