### PR TITLE
WIP: add lib key mini specifications and active proposals to the website

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site/*
 Gemfile
 *.lock
 media/logo.ai
+_site/

--- a/README.md
+++ b/README.md
@@ -51,3 +51,14 @@ Open an [issue](https://github.com/unified-font-object/ufo-spec/issues) and disc
 
 ## Meetings
 Historically there are informal meetings about the specification around the Robothon conference (held every three years). On July 31, 2020, we had the first open virtual meeting, the [notes of which are online](https://docs.google.com/document/d/1REf695Yxnu3aj_UqcVfF0WTyV8PUaPo-r6duEHxtj48/edit).
+
+## How to edit this website
+
+Clone the repository, install [Jekyll](https://jekyllrb.com/docs/) then run:
+
+```bash
+jekyll serve
+```
+
+Then your can find the built website at http://127.0.0.1:4000/
+The built website will keep updating as you edit (just refresh it).

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ email: tal@typesupply.com
 description: > # this means to ignore newlines until "baseurl:"
   The Unified Font Object (UFO) is a cross-platform, cross-application, human
   readable, future proof format for storing font data.
-baseurl: "/" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://unifiedfontobject.org" # the base hostname & protocol for your site
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
@@ -25,6 +25,15 @@ kramdown:
 
 permalink: /:title/
 
+# Collection of mini specifications (to enable rendering an index of them)
+# See documentation: https://jekyllrb.com/docs/collections/
+collections:
+  lib_and_data:
+    output: true
+    permalink: /extensions/:collection/:name
+  proposals:
+    output: true
+    permalink: /extensions/:collection/:name
 
 gems:
   - rouge

--- a/_includes/lib_and_data_reference.html
+++ b/_includes/lib_and_data_reference.html
@@ -1,0 +1,29 @@
+<h2>Reference</h2>
+
+<!-- No sorting, it makes it easier to control the "story" of the page -->
+{% assign keys = page.lib_and_data_keys %}
+{% for key in keys %}
+<h3 id="{{ key.location | slugify }}_{{ key.name | slugify }}">
+    <code>{{ key.name }}</code>
+</h3>
+
+<table>
+    <tr>
+        <th>Location</th>
+        <td>{{ key.location }}</td>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>{{ key.type }}</td>
+    </tr>
+    <tr>
+        <th>Example</th>
+        <td>{{ key.example_md | markdownify }}</td>
+    </tr>
+    <tr>
+        <th>Description</th>
+        <td>{{ key.description_md | markdownify }}</td>
+    </tr>
+</table>
+
+{% endfor %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,6 +7,9 @@
                 {% if item.title == "UFO 1" %}
                     <li class="navigationSectionTitle">Versions</li>
                 {% endif %}
+                {% if item.title == "Lib and data" %}
+                    <li class="navigationSectionTitle">Extensions</li>
+                {% endif %}
                 <li><a {% if item.url == page.url %}class="active"{% endif %} href="{{ item.url | prepend: site.baseurl }}">{{ item.title }}</a></li>
                 {% if item.tree %}
                     <ul class="navigationNested {% if page.url contains item.url %} active{% endif %}">

--- a/_lib_and_data/glyphs.app_instance_attributes.md
+++ b/_lib_and_data/glyphs.app_instance_attributes.md
@@ -1,0 +1,133 @@
+---
+layout: default
+title: Glyphs.app Instance Attributes
+summary: |
+    Glyphs.app allows to configure more information about each instance
+    than what fits in the Designspace format. Some of that information is
+    useful for other tools than Glyphs.app.
+
+lib_and_data_keys:
+  - name: com.schriftgestaltung.export
+    location: Designspace instance lib
+    type: boolean
+    example_md: |
+        ```xml
+        <instance name="Only visible in Glyphs.app">
+            <lib>
+                <dict>
+                    <key>com.schriftgestaltung.export</key>
+                    <false/>
+                </dict>
+            </lib>
+        </instance>
+        ```
+    description_md: |
+        Mark this instance as only visible in the Glyphs.app UI, but not
+        to be generated when building fonts. Designers often use this to
+        proof intermediate weights.
+
+        `fontmake` will skip such instances when generating fonts from
+        the Designspace file.
+
+  - name: com.schriftgestaltung.weight
+    location: Designspace instance lib
+    type: string
+    example_md: |
+        ```xml
+        <instance name="Make my OS/2 usWeightClass 200">
+            <lib>
+                <dict>
+                    <key>com.schriftgestaltung.weight</key>
+                    <string>ExtraLight</string>
+                </dict>
+            </lib>
+        </instance>
+        ```
+    description_md: |
+        Glyphs.app allows generated instances to have a custom OS/2
+        [usWeightClass](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass),
+        potentially disconnected from their location along the font's weight
+        axis.
+
+        This key stores the name what the user has selected in Glyphs.app's
+        Weight dropdown for instances ([see their
+        tutorial](https://glyphsapp.com/tutorials/multiple-masters-part-3-setting-up-instances)).
+
+        The mapping from the strings used in Glyphs.app's UI and the OS/2
+        values can be found in [`glyphsLib`'s source
+        code](https://github.com/googlefonts/glyphsLib/blob/3e0c6de4aa657156428ccc63dd4576f6cc706563/Lib/glyphsLib/classes.py#L210-L226):
+        ```python
+        WEIGHT_CODES = {
+            "Thin": 100,
+            "ExtraLight": 200,
+            "UltraLight": 200,
+            "Light": 300,
+            None: 400,  # default value normally omitted in source
+            "Normal": 400,
+            "Regular": 400,
+            "Medium": 500,
+            "DemiBold": 600,
+            "SemiBold": 600,
+            "Bold": 700,
+            "UltraBold": 800,
+            "ExtraBold": 800,
+            "Black": 900,
+            "Heavy": 900,
+        }
+        ```
+
+
+  - name: com.schriftgestaltung.width
+    location: Designspace instance lib
+    type: string
+    example_md: |
+        ```xml
+        <instance name="Make my OS/2 usWidthClass 5">
+            <lib>
+                <dict>
+                    <key>com.schriftgestaltung.width</key>
+                    <string>Medium (normal)</string>
+                </dict>
+            </lib>
+        </instance>
+        ```
+    description_md: |
+        Glyphs.app allows generated instances to have a custom OS/2
+        [usWidthClass](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass),
+        potentially disconnected from their location along the font's width
+        axis.
+
+        This key stores the name what the user has selected in Glyphs.app's
+        Width dropdown for instances ([see their
+        tutorial](https://glyphsapp.com/tutorials/multiple-masters-part-3-setting-up-instances)).
+
+        The mapping from the strings used in Glyphs.app's UI and the OS/2
+        values can be found in [`glyphsLib`'s source
+        code](https://github.com/googlefonts/glyphsLib/blob/3e0c6de4aa657156428ccc63dd4576f6cc706563/Lib/glyphsLib/classes.py#L228-L239):
+        ```python
+        WIDTH_CODES = {
+            "Ultra Condensed": 1,
+            "Extra Condensed": 2,
+            "Condensed": 3,
+            "SemiCondensed": 4,
+            None: 5,  # default value normally omitted in source
+            "Medium (normal)": 5,
+            "Semi Expanded": 6,
+            "Expanded": 7,
+            "Extra Expanded": 8,
+            "Ultra Expanded": 9,
+        }
+        ```
+---
+
+[Glyphs.app](https://glyphsapp.com/) allows to configure more information
+about each instance than what fits in the Designspace format, so everything
+extra is stored in the Designspace instance's lib when converting the
+`.glyphs` file with [`glyphsLib`](https://github.com/googlefonts/glyphsLib).
+
+Some of that extra instance information will be interpreted by
+[`fontmake`](https://github.com/googlefonts/fontmake) and
+[`ufo2ft`](https://github.com/googlefonts/ufo2ft) to build instances in a
+similar way as Glyphs.app does.
+
+{% include lib_and_data_reference.html %}

--- a/_proposals/designspace_5.md
+++ b/_proposals/designspace_5.md
@@ -1,0 +1,244 @@
+---
+layout: default
+title: Designspace 5.0
+summary_md: |
+    This proposes to extend the Designspace format to make it possible to:
+
+    * have a single designspace file for a whole font project,
+    * that covers both interpolatable sources and non-interpolatable ones (e.g. uprights vs italics),
+    * that includes STAT information, and
+    * that lists all the "products" that can be built from the source files, i.e. several variable fonts and several static instances.
+---
+
+This is a proposed update to the
+[Designspace](https://github.com/fonttools/fonttools/tree/master/Doc/source/designspaceLib)
+file format that standardises the following Dalton Maag practices:
+
+* Allow to mix interpolatable sources and some that are not, as long as they're
+part of the same "design space". Introduce discrete axes to organize these
+sources. Example: uprights and italics. The goal is to have 1 designspace file
+for any cohesive font project, with everything listed in one place. This goes
+hand-in-hand with the next points.
+
+* Provide STAT table information from the start, and include it in the
+Designspace file format. Also allow to provide STAT information for linked
+families that are not interpolatable (e.g. Source Sans Roman and Source Sans
+Italic) in one single Designspace file. This feature would supersede the
+external Stylespace files that Nikolaus developed (see
+[statmake](https://github.com/daltonmaag/statmake))
+  * Only one copy of the STAT information is maintained, and it is attached to
+    the data that it describes (i.e. the usual contents of desispace files).
+
+    Alternative options at the moment don't achieve this:
+      * `statmake`'s file is next to the designspace, and needs to be kept
+        up-to-date separately
+      * Writing STAT information in a feature file is also separate from the
+        designspace and needs to be updated separately.
+  * We can use the STAT information to provide default lists of named instances
+    to be included in the defined variable fonts.
+
+* Define more clearly what can be "produced" from a Designspace by running it
+  through a compiler such as `fontmake`, i.e. list explicitly the outputs of
+  the build process in the designspace. This achieves two things:
+  * We can just feed the designspace to a compiler and get everything we
+    expect from it without fiddling with compiler options
+  * Because possible outputs are defined explicitly, we can refer to them and
+    associate data to them. For example: if the designspace defines two
+    variable fonts, and we have two special font tables dumped in TTX format
+    to mix into these two fonts, we can express the link between each font
+    and each TTX dump.
+
+* Continous and discrete axes will define groups of sources that are
+interpolatable. (or maybe we need to explicitly define these groups? To be
+discussed). From there:
+  * Define several variable fonts from the same set of interpolatable sources.
+    This would allow VF projects with several axes such as Aktiv Grotesk to
+    have only 1 Designspace file that describes all 5 variable fonts that we
+    ship (instead of the current situation where we write 5 Designspace files
+    with repeated information).
+  * Define several static instances from each group of interpolatable sources.
+
+## Related discussions
+
+* UFS: https://github.com/unified-font-object/ufo-spec/issues/86
+* Original STAT-in-Designspace (before `statmake`):
+https://github.com/fonttools/fonttools/issues/1507
+
+
+## Sample files
+
+### `SourceSans.designspace`
+
+This example file demonstrates how to:
+* include STAT table information
+* rely on it to get correctly named instances
+* mix interpolatable and discrete axes
+* define several variable fonts from the "design space"
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<designspace format="5.0">
+  <axes>
+    <axis default="200" maximum="900" minimum="200" name="Weight" tag="wght">
+      <map input="200" output="0" />
+      <map input="300" output="100" />
+      <map input="400" output="368" />
+      <map input="600" output="600" />
+      <map input="700" output="824" />
+      <map input="900" output="1000" />
+      <!-- All axes provide STAT information with the "labels" element. -->
+      <labels>
+        <label minimum="0" value="0" maximum="50" name="Extra Light" />
+        <label minimum="50" value="100" maximum="234" name="Light" />
+        <label minimum="234" value="368" maximum="484" name="Regular" elidable="true" />
+        <label minimum="484" value="600" maximum="712" name="Semi Bold" />
+        <label minimum="712" value="824" maximum="912" name="Bold" />
+        <label minimum="912" value="1000" maximum="1000" name="Black" />
+        <label value="368" name="Regular" elidable="true" linkedvalue="824" />
+      </labels>
+    </axis>
+    <!--
+      Discrete axes provide a list of discrete `values` instead of the usual
+      `minimum` and `maximum`. The `values` are space-separated numbers. There
+      can be more than 2. No interpolation is allowed between these.
+    -->
+    <axis default="0" values="0 1" name="Italic" tag="ital">
+      <labels>
+        <!-- Discrete axes also provide STAT information. -->
+        <label value="0" name="Roman" elidable="true" linkedvalue="1" />
+        <label value="1" name="Italic" />
+      </labels>
+    </axis>
+  </axes>
+
+  <sources>
+    <source filename="Roman/Masters/master_0/SourceSans_ExtraLight.ufo">
+      <info copy="1" />
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </source>
+    <source filename="Roman/Masters/master_1/SourceSans_Black.ufo">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </source>
+    <source filename="Italic/Masters/master_0/SourceSans_ExtraLight.ufo">
+      <info copy="1" />
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+    </source>
+    <source filename="Italic/Masters/master_1/SourceSans_Black.ufo">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+    </source>
+  </sources>
+
+  <variable-fonts>
+    <!--
+      Each variable font is a subset of the axes provided at the top.
+      Continuous axes can be included either:
+        * in full,
+        * or only on a reduced interval (different minimum-maximum),
+        * or only at 1 discrete location
+      Dicrete axes cannot be included in full, and we must specify a value
+      (or the compiler should assume the default value).
+    -->
+    <variable-font>
+      <!-- This one is the Roman (default location along ital),
+           with full range for the Weight axis. -->
+      <axes>
+        <axis name="Weight"/>
+      </axes>
+    </variable-font>
+    <variable-font>
+      <!-- This one is the Italic, with full range for the Weight axis. -->
+      <axes>
+        <axis name="Weight"/>
+        <axis name="Italic" value="1"/>
+      </axes>
+    </variable-font>
+    <variable-font>
+      <!-- As an example, this would be the Roman with a reduced range. -->
+      <axes>
+        <axis name="Weight" minimum="400" maximum="700" default="400"/>
+        <axis name="Italic" value="0"/>
+      </axes>
+    </variable-font>
+  </variable-fonts>
+
+  <instances>
+    <instance>
+      <!--
+        Using the STAT information provided above, the names of the instances
+        can be generated, and don't need to be specified, except to override
+        the generated names (but then you might as well fix your STAT data).
+        Example:
+        Source Sans Extra Light
+        familyName: "Source Sans"
+        styleName: "Extra Light"
+        postScriptFontName: "SourceSans-ExtraLight"
+      -->
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+    <instance>
+      <!-- Source Sans Light -->
+      <location>
+        <dimension name="Weight" xvalue="100" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+    <instance>
+      <!--
+        Source Sans Regular
+        (because elidable fallback name ID defaults to 2.
+      -->
+      <location>
+        <dimension name="Weight" xvalue="368" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+    <instance>
+      <!-- Source Sans Semi Bold -->
+      <location>
+        <dimension name="Weight" xvalue="600" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+    <instance>
+      <!--
+        Source Sans Bold
+        [...]
+        styleMapStyleName: "bold"
+      -->
+      <location>
+        <dimension name="Weight" xvalue="824" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+    <instance>
+      <!-- Source Sans Black -->
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </instance>
+  </instances>
+</designspace>
+```
+
+
+## Details of proposed changes to the specification
+
+Ideally should be a merge request in fontTools/designspaceLib (once the
+modifications described are deemed generally good ideas).
+

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -12,7 +12,7 @@
     --color-green : rgb(0, 180, 0);
     --color-blue : rgb(0, 0, 180 );
     --color-magenta : rgb(230, 0, 220);
-    
+
     --color-background: var(--color-white);
     --color-text: var(--color-black);
     --color-link: var(--color-red);
@@ -69,7 +69,7 @@ body {
 
 }
 
-// Navigation 
+// Navigation
 
 #navigation {
     position: fixed;
@@ -80,7 +80,7 @@ body {
     border-top: 1px solid var(--color-quiet);
 }
 
-// Content 
+// Content
 
 #content {
     position: relative;
@@ -123,14 +123,12 @@ a {
     }
 }
 
-// Body Text 
+// Body Text
 
 p {
     margin: 0;
     padding: 0 0 0.55em 0;
 }
-
-// Headers
 
 h1 {
     padding: 0 0 0.4em 0;
@@ -185,7 +183,7 @@ h6 {
     line-height: 1.2em;
 }
 
-// Intro 
+// Intro
 
 h1.intro {
     padding: 0.5em;
@@ -196,10 +194,10 @@ h1.intro {
     line-height: 1.25em;
 }
 
-// Code 
+// Code
 
 pre {
-    overflow: hidden;
+    overflow-y: auto;
     margin: 1em 0;
     padding: 0.5em 0.75em;
     font-family: "IBM Plex Mono";
@@ -216,7 +214,7 @@ code {
     background-color: var(--color-block);
 }
 
-// Table 
+// Table
 
 table {
     width: 100%;
@@ -255,10 +253,10 @@ table {
     td:nth-last-child(1) {
         padding-right: 0;
     }
-    
+
 }
 
-// Specification Tables 
+// Specification Tables
 
 table.name-description td:nth-child(1) {
     width: 6em;
@@ -287,7 +285,7 @@ table.name-type-description-default td:nth-child(4) {
     font-style: italic;
 }
 
-// Example Tables 
+// Example Tables
 
 table.example-group td:nth-child(1) {
     width: 25%;
@@ -304,7 +302,7 @@ table.example-kerning td:nth-child(2) {
 table.example-kerning td:nth-child(3) {
 }
 
-// File Format Table 
+// File Format Table
 
 table.fileformat {
     width: auto;
@@ -323,7 +321,7 @@ table.fileformat a:hover {
     color: var(--color-background);
 }
 
-// Lists 
+// Lists
 
 ul, ol {
     font-family: "IBM Plex Sans";
@@ -331,7 +329,7 @@ ul, ol {
     padding-left: 0;
 }
 
-// File Diagram 
+// File Diagram
 
 ul.filediagram {
     margin: 0.5em 0;
@@ -353,7 +351,7 @@ ul.filediagram {
 
 }
 
-// Algorithm Diagram 
+// Algorithm Diagram
 
 ul.algorithmdiagram {
     margin: 1em 0;
@@ -376,7 +374,7 @@ ul.algorithmdiagram {
 
 }
 
-// Navigation 
+// Navigation
 
 #navigation {
     ul {
@@ -428,7 +426,7 @@ ul.algorithmdiagram {
     display: none;
 }
 
-// Anchors 
+// Anchors
 
 a.header-link {
     padding-left: 0.15em;

--- a/extensions/lib_and_data/index.md
+++ b/extensions/lib_and_data/index.md
@@ -1,0 +1,27 @@
+---
+layout: default
+navigation: true
+order: 1000
+title: Lib and data
+---
+
+The Designspace and UFO formats allow arbitrary information to be associated with various objects of the format.
+These pages aim to provide informal specification for all lib keys and data files that may be used by more than one authoring tool or compiler.
+
+This documentation effort only concerns versions 4+ of Designspace and 3+ of UFO.
+
+{% for lib_and_data in site.lib_and_data %}
+<h2><a href="{{ lib_and_data.url }}">{{ lib_and_data.title }}</a></h2>
+
+<p>{{ lib_and_data.summary }}</p>
+
+<ul>
+{% for key in lib_and_data.lib_and_data_keys %}
+    <li>
+    <a href="{{ lib_and_data.url }}#{{ key.location | slugify }}_{{ key.name | slugify }}">
+        <code>{{ key.name }}</code>
+    </a>
+    </li>
+{% endfor %}
+</ul>
+{% endfor %}

--- a/extensions/proposals/index.md
+++ b/extensions/proposals/index.md
@@ -1,0 +1,16 @@
+---
+layout: default
+navigation: true
+order: 1100
+title: Proposals
+---
+
+Active proposals to extend or improve the Designspace or UFO specifications are listed on this page while they are maturing. Once accepted into the official specification, they will be moved to the appropriate section.
+
+{% for proposal in site.proposals %}
+<h2><a href="{{ proposal.url }}">{{ proposal.title }}</a></h2>
+
+{{ proposal.summary_md | markdownify }}
+
+<p><a href="{{ proposal.url }}">Full proposal →</a></p>
+{% endfor %}


### PR DESCRIPTION
Start implementing #118 (work in progress, suggestions very welcome!)

Live preview version here: https://daltonmaag.github.io/ufo-spec/extensions/lib_and_data/

I documented three lib keys that are actually Designspace lib keys, and added our Designspace 5.0 proposal.

I chose to allow documenting several lib keys on the same page, because I think it allows for better grouping of information. You can write a common introduction and provide relevant links for all the keys on the page. Then, most of the information about each lib key is structured as YAML. That allows to auto-generate both the "reference tables" for each key and an index page that lists all the keys and provides links with anchors directly to that key's reference table. That index is meant to be Ctrl-F-friendly.

New additions only need to create new files in the `_lib_and_data` folder, and follow the same organization of the YAML frontmatter ([see example file](https://github.com/daltonmaag/ufo-spec/blob/gh-pages/_lib_and_data/glyphs.app_instance_attributes.md), the "structured" display on Github is not great but I think it looks alright as a basic text file.) The new files will be picked up automatically and added to the index page.

I'm quite happy about that organization, what do you think?

I didn't handle Designspace/UFO version numbers, do you think that it should it be added as a field to each lib key? Or are we going to document only the latest version of the format anyway?

I'm going to keep documenting a few more keys, also some in UFOs libs, and see if I run into any issues with this organization.

As I said I also added a proposal there, I don't remember whether we discussed this, but I think it would make sense to have active/work-in-progress proposals live on the website? The example is our Designspace 5.0 proposal: https://daltonmaag.github.io/ufo-spec/extensions/proposals/designspace-5
