### PR TITLE
Prevent horizontal overflow on mobile (closes #137)

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -534,7 +534,7 @@ h6:hover>.header-link {
         display: block;
         width: 90%;
         margin: 1em auto;
-        padding: 0;
+        padding: 0 0 5rem 0;
         border: none;
         transition-duration: var(--transition-duration);
         transition-property: left;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -30,6 +30,8 @@
     --weight-base: var(--weight-light);
 
     --transition-duration: 0.25s;
+
+    --max-column-width: 80ch; // 80 average characters (based on width of "zero" glyph) of main font
 }
 
 
@@ -104,6 +106,10 @@ body {
     font-weight: var(--weight-base);
     font-size: 17px;
     line-height: 1.5em;
+}
+
+p, ul {
+    max-width: var(--max-column-width);
 }
 
 a {
@@ -453,7 +459,7 @@ h6:hover>.header-link {
 // Responsive
 // ----------
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 1150px) {
     
     #wrapper {
         position: absolute;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -546,3 +546,15 @@ h6:hover>.header-link {
 
     
 }
+
+@media only screen and (max-width: 400px) {
+    // prevent overflow for words as long as "contributing" on small screens
+    h1 {
+        font-size: 15vw;
+    }
+
+    // "Thin" renders somewhat poorly on iPhone screens, so this makes it just slightly thicker
+    h1.intro {
+        font-weight: var(--weight-extralight);
+    }
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -460,6 +460,7 @@ h6:hover>.header-link {
         left: 0;
         top: 0;
         width: 100%;
+        overflow-x: hidden;
     }
 
     #logo {
@@ -543,4 +544,5 @@ h6:hover>.header-link {
         font-size: 1.5em;
     }
 
+    
 }


### PR DESCRIPTION
See https://github.com/unified-font-object/ufo-spec/issues/137 for the fixes this makes.

This also adds a bit of padding to the bottom of `.content` on screens under 400px in width, as a small but useful reading improvement.