### PR TITLE
Simplify dev workflow by removing unneeded baseUrl from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ email: tal@typesupply.com
 description: > # this means to ignore newlines until "baseurl:"
   The Unified Font Object (UFO) is a cross-platform, cross-application, human
   readable, future proof format for storing font data.
-baseurl: "/" # the subpath of your site, e.g. /blog
 url: "http://unifiedfontobject.org" # the base hostname & protocol for your site
 
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking


### PR DESCRIPTION
I _think_ we could probably remove the `baseUrl` line from config, and it would still build correctly locally & on GitHub pages. If so, that would eliminate manual tweaks that have to be done for development. 

I have tested this in my fork, and it seems to be working well, so far:

https://arrowtype.github.io/ufo-spec/