### PR TITLE
Make navigation menu scrollable

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -79,6 +79,9 @@ body {
     margin-top: 11.5em;
     padding-top: 1em;
     border-top: 1px solid var(--color-quiet);
+    top: 5.5em;
+    bottom: 0;
+    overflow: auto;
 }
 
 // Content 


### PR DESCRIPTION
Otherwise, on laptop-sized screens, the lower part of the navigation is inaccessible.