### PR TITLE
[version/ufo3/glif.md] add lib key 'public.openTypeCategory'

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -418,6 +418,10 @@ This key provides a dictionary of data containing object-level lib data for indi
 </dict>
 ```
 
+### public.openTypeCategory
+
+This key is used to define the glyph class of the glyph to be used, for example, in the [OpenType GDEF Glyph Class Definition Table]. The value must be one of following strings : `base`, `mark`, `ligature`, `component`. This data is optional.
+
 ### Example
 
 ```xml
@@ -518,5 +522,6 @@ This key provides a dictionary of data containing object-level lib data for indi
   [XML Property List]: ../../conventions/#xml-property-lists
   [reverse domain naming scheme]: ../../conventions/#reverse-domain-naming-schemes
   [data directory]: ../../data
+  [OpenType GDEF Glyph Class Definition Table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table
   [OpenType GDEF Ligature Caret List table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table-overview
   [control characters]: ../../conventions/#controls


### PR DESCRIPTION
This adds the UFO3 glif lib key `public.openTypeCategory` to be used in the [GDEF Glyph Class Definition table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table) as proposed in [Support for storing glyph category #146](https://github.com/unified-font-object/ufo-spec/issues/146) (see [comment](https://github.com/unified-font-object/ufo-spec/issues/146#issuecomment-717887385)).

FontLab Studio 5, FontLab VI and 7, and FontForge can store the GDEF Glyph Class type per glyph.
These implementations or others may make use of this public lib key.

Glyphs.app has a more refined set of categories and subcategories defined for each glyph which would not fit in this public lib key.