### PR TITLE
add lib key 'public.openTypeCategories' and remove from glyph lib

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -430,10 +430,6 @@ This key provides a dictionary of data containing object-level lib data for indi
 </dict>
 ```
 
-### public.openTypeCategory
-
-This key is used to define the glyph class of the glyph to be used, for example, in the [OpenType GDEF Glyph Class Definition Table]. The value must be one of following strings : `base`, `mark`, `ligature`, `component`. This data is optional.
-
 ### Example
 
 ```xml
@@ -534,6 +530,5 @@ This key is used to define the glyph class of the glyph to be used, for example,
   [XML Property List]: ../../conventions/#xml-property-lists
   [reverse domain naming scheme]: ../../conventions/#reverse-domain-naming-schemes
   [data directory]: ../../data
-  [OpenType GDEF Glyph Class Definition Table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table
   [OpenType GDEF Ligature Caret List table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table-overview
   [control characters]: ../../conventions/#controls

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -36,6 +36,24 @@ This data is optional.
 
 [The OpenType meta table specification.]
 
+#### public.openTypeCategory
+
+This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name, each value must be one of `base`, `mark`, `ligature` or `component`. This data is optional.
+
+```xml
+<key>public.openTypeCategory</key>
+<dict>
+  <key>A</key>
+  <string>base</string>
+  <key>B</key>
+  <string>base</string>
+  <key>f_f</key>
+  <string>ligature</string>
+  <key>acutecomb</key>
+  <string>mark</string>
+</dict>
+```
+
 #### public.postscriptNames
 
 This defines a preferred glyph name to Postscript glyph name mapping for glyphs in the font. Authoring tools should use the values defined in this mapping when outputting font data formats such as the `post` and `CFF ` tables in OpenType. This data is optional.
@@ -123,3 +141,4 @@ This key provides a dictionary of data containing object-level lib data for indi
   [data directory]: ../data
   [reverse domain naming scheme]: ../conventions/#reverse-domain-naming-schemes
   [The OpenType meta table specification.]: http://www.microsoft.com/typography/otspec/meta.htm
+  [OpenType GDEF Glyph Class Definition Table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -38,7 +38,9 @@ This data is optional.
 
 #### public.openTypeCategories
 
-This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name, each value must be one of `base`, `mark`, `ligature` or `component`. This data is optional.
+This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name. Both key and values must be strings. Values must be one of `base`, `mark`, `ligature` or `component`. This data is optional.
+
+The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font.
 
 ```xml
 <key>public.openTypeCategories</key>

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -36,12 +36,12 @@ This data is optional.
 
 [The OpenType meta table specification.]
 
-#### public.openTypeCategory
+#### public.openTypeCategories
 
 This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name, each value must be one of `base`, `mark`, `ligature` or `component`. This data is optional.
 
 ```xml
-<key>public.openTypeCategory</key>
+<key>public.openTypeCategories</key>
 <dict>
   <key>A</key>
   <string>base</string>


### PR DESCRIPTION
See [Support for storing glyph category #146](https://github.com/unified-font-object/ufo-spec/issues/146) and in particular the discussion under https://github.com/unified-font-object/ufo-spec/issues/146#issuecomment-768210154.