### PR TITLE
Add public.truetype.overlap and public.truetype.compositeFlags

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -482,7 +482,8 @@ This key provides a dictionary of data containing object-level lib data for indi
 {: .name-type-description }
 | key | type | description |
 |--|--|--|
-| public.truetype.compositeFlags | list | This key is used in a component object-level dictionary and provides a list of bit that should be set in the TrueType Composite Glyph flags. The bit numbers that can be set are bits 4 (ROUND_XY_TO_GRID) or 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description]. **Note**: Bit 10 (OVERLAP_COMPOUND) should be taken from the glyph lib key "public.truetype.overlap" for the first component and should not be set for other components. Any other bit must not be set here and should be set by authoring tools in TrueType binaries. Authoring tools may ignore this data. This data is optional.
+| public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 4 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
+| public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. It may be used to update the `xOffset, yOffset` of the component and the `width` of the glyph it is in. Authoring tools may ignore this data. This data is optional.
 
 ### Example
 

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -482,7 +482,7 @@ This key provides a dictionary of data containing object-level lib data for indi
 {: .name-type-description }
 | key | type | description |
 |--|--|--|
-| public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 2 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
+| public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 2 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
 | public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. It may be used to update the `xOffset, yOffset` of the component and the `width`, `height` and `verticalOrigin` of the glyph it is in. Authoring tools may ignore this data. This data is optional.
 
 ### Example

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -397,6 +397,10 @@ IUP[1]  /* InterpolateUntPts */
 | id | string | Hash of glyph outlines which may have been processed by authoring tools. This is computed when the instructions dict is created or modified. It is used to determine if the glyph outlines have changed since the glyph was hinted: if it has, then the instructions for the glyph should not be used by authoring tools. See "Hint ID Computation" below. |
 | assembly | string | TrueType instructions assembly as a string. The assembly is represented by a single string of fontTools TrueType instructions assembly with optional line formatting between instructions. |
 
+#### public.truetype.overlap
+
+This key is a boolean used for indicating the glyph contours or components may have overlap.
+Authoring tools may use this to set bit 6 (OVERLAP_SIMPLE) in the TrueType Simple Glyph flags or bit 10 (OVERLAP_COMPOUND) in the TrueType Composite Glyph flags listed in the [OpenType glyf Simple Glyph Description] and the [OpenType glyf Composite Glyph Description]. Authoring tools may ignore or override this data. This data is optional.
 
 ##### public.verticalOrigin
 

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -482,8 +482,8 @@ This key provides a dictionary of data containing object-level lib data for indi
 {: .name-type-description }
 | key | type | description |
 |--|--|--|
-| public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 4 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
-| public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. It may be used to update the `xOffset, yOffset` of the component and the `width` of the glyph it is in. Authoring tools may ignore this data. This data is optional.
+| public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 2 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
+| public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. It may be used to update the `xOffset, yOffset` of the component and the `width`, `height` and `verticalOrigin` of the glyph it is in. Authoring tools may ignore this data. This data is optional.
 
 ### Example
 

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -477,6 +477,13 @@ This key provides a dictionary of data containing object-level lib data for indi
 </dict>
 ```
 
+##### Standardized object lib keys
+
+{: .name-type-description }
+| key | type | description |
+|--|--|--|
+| public.truetype.compositeFlags | list | This key is used in a component object-level dictionary and provides a list of bit that should be set in the TrueType Composite Glyph flags. The bit numbers that can be set are bits 4 (ROUND_XY_TO_GRID) or 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description]. **Note**: Bit 10 (OVERLAP_COMPOUND) should be taken from the glyph lib key "public.truetype.overlap" for the first component and should not be set for other components. Any other bit must not be set here and should be set by authoring tools in TrueType binaries. Authoring tools may ignore this data. This data is optional.
+
 ### Example
 
 ```xml
@@ -578,4 +585,6 @@ This key provides a dictionary of data containing object-level lib data for indi
   [reverse domain naming scheme]: ../../conventions/#reverse-domain-naming-schemes
   [data directory]: ../../data
   [OpenType GDEF Ligature Caret List table]: https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#ligature-caret-list-table-overview
+  [OpenType glyf Composite Glyph Description]: https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#composite-glyph-description
+  [OpenType glyf Simple Glyph Description]: https://docs.microsoft.com/en-us/typography/opentype/spec/glyf#simple-glyph-description
   [control characters]: ../../conventions/#controls

--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -483,7 +483,7 @@ This key provides a dictionary of data containing object-level lib data for indi
 | key | type | description |
 |--|--|--|
 | public.truetype.roundOffsetToGrid | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 2 (ROUND_XY_TO_GRID) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. Authoring tools may ignore this data. This data is optional.
-| public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. It may be used to update the `xOffset, yOffset` of the component and the `width`, `height` and `verticalOrigin` of the glyph it is in. Authoring tools may ignore this data. This data is optional.
+| public.truetype.useMyMetrics | boolean | This key is used in a component object-level dictionary and, when set to true, indicates bit 9 (USE_MY_METRICS) listed in the [OpenType glyf Composite Glyph Description] should be set for the component in the Component Glyph flags in TrueType binaries. This data is optional.
 
 ### Example
 


### PR DESCRIPTION
Fixes https://github.com/unified-font-object/ufo-spec/issues/162.

This adds a glyph lib key `public.truetype.overlap` as a boolean and the component object-level lib keys `public.truetype.useMyMetrics` and `public.truetype.roundOffsetToGrid` as boolean as well.

The overlap can be used to set the TrueType Simple Glyph flags bit 6 (OVERLAP_SIMPLE) or the Component Glyph flags bit 10 (OVERLAP_COMPOUND).

The roundOffsetToGrid can be used to set the Component Glyph flags bit 2 (ROUND_XY_TO_GRID).

The useMyMetrics can be used to set the Component Glyph flags bit 9 (USE_MY_METRICS). In theory tools may use this to update the xOffset and yOffset of a component and the width, as well as height and verticalOrigin, of the composite glyph that contains it.