### PR TITLE
public.openTypeCategories: add 'unassigned' value

### DIFF
--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -38,7 +38,7 @@ This data is optional.
 
 #### public.openTypeCategories
 
-This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name. Both key and values must be strings. Values must be one of `base`, `mark`, `ligature` or `component`. This data is optional.
+This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name. Both key and values must be strings. Values must be one of `unassigned`, `base`, `mark`, `ligature` or `component`. This data is optional.
 
 The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font.
 

--- a/versions/ufo3/lib.plist.md
+++ b/versions/ufo3/lib.plist.md
@@ -41,6 +41,8 @@ This data is optional.
 This key is used to define the category of the glyphs to be used, for example, as glyph class in the [OpenType GDEF Glyph Class Definition Table]. The categories are stored in a dictionary keyed by glyph name. Both key and values must be strings. Values must be one of `unassigned`, `base`, `mark`, `ligature` or `component`. This data is optional.
 
 The dictionary may contain glyph names that are not in the font. The dictionary may not contain a key, value pair for all glyphs in the font.
+**Note:** If a glyph's category is not defined in the dictionary, authoring tools may assign it to any glyph class in the OpenType GDEF Glyph Class Definition Table.
+
 
 ```xml
 <key>public.openTypeCategories</key>


### PR DESCRIPTION
Besides the four GDEF glyphs classes: class 1 for bases, class 2 for ligatures, class 3 for marks, class 4 for components, there is also class 0 for any glyph not assigned a class value. See [Glyph Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table).
It can be useful to differentiate between glyphs that don't have any specified category in UFO, leaving it to authoring tools to assign a GDEF glyphs class in the font, and glyphs that are specified to be in the `unassigned` category in UFO, for which authoring tools should not put in any of the classes 1 to 4.