### PR TITLE
Add minor clarifications to outline and contour emptiness semantics

### DIFF
--- a/versions/ufo3/glyphs/glif.md
+++ b/versions/ufo3/glyphs/glif.md
@@ -206,6 +206,11 @@ Authoring tools may convert instances of contours like this to anchor elements w
 {: #outline }
 ### outline: Outline description.
 
+Note that this element contains descriptions of graphical data. Therefore, 
+
+1. an empty outline element is semantically equivalent to the element not existing in the first place.
+2. an empty contour element is semantically equivalent to the element not existing in the first place.
+
 #### This element has no attributes.
 
 #### Child Elements


### PR DESCRIPTION
This is for normalization purposes.

Not sure if this needs to be said in the spec, but ufonormalizer does it and I remember someone from the UFO team saying that it makes sense.